### PR TITLE
fix #9 and #10 , static include format for Chicken version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,4 @@
 Haskell/swapview2
 Java/*.class
 NodeJS/node_modules
-Chicken/*.so
-Chicken/*.o
-Chicken/*.setup-info
+Chicken/format

--- a/C++14/swapview.cpp
+++ b/C++14/swapview.cpp
@@ -46,10 +46,9 @@ string strformat(UArgs... args){
     return StrFormatHelper<UArgs...>(args...);
 }
 
-string readline(string path){
+string readall(string path){
     ifstream fs(path);
-    string buf;
-    getline(fs, buf);
+    string buf((istreambuf_iterator<char>(fs)), istreambuf_iterator<char>());
     return buf;
 }
 
@@ -111,9 +110,10 @@ string filesize(auto size){
 }
 
 swap_info getSwapFor(int pid){
-    string comm = readline(strformat("/proc/", pid, "/cmdline"));
+    string comm = readall(strformat("/proc/", pid, "/cmdline"));
     if(comm.length() > 0){
-      replace(comm.begin(), comm.end()-1, '\0' , ' ');
+      replace(comm.begin(), comm.end(), '\0' , ' ');
+      comm.pop_back();
     }
     double s=0.0;
     for(auto l: readlines(strformat("/proc/", pid, "/smaps"))){

--- a/C++98/swapview.cpp
+++ b/C++98/swapview.cpp
@@ -81,11 +81,11 @@ string filesize(double size){
 swap_info getSwapFor(int pid){
     ostringstream cmdline, smaps;
     cmdline << "/proc/" << pid << "/cmdline";
-    string comm;
     ifstream fs(cmdline.str().c_str());
-    getline(fs, comm);
+    string comm((istreambuf_iterator<char>(fs)), istreambuf_iterator<char>());
     if(comm.length() > 0){
-      replace(comm.begin(), comm.end()-1, '\0' , ' ');
+      replace(comm.begin(), comm.end(), '\0' , ' ');
+      comm.erase(comm.end()-1);
     }
     double s=0.0;
     smaps << "/proc/" << pid << "/smaps";

--- a/Chicken/Makefile
+++ b/Chicken/Makefile
@@ -1,12 +1,12 @@
 default: swapview
 
-swapview: swapview.scm .libraries.stamp
-	csc -O4 swapview.scm
+swapview: swapview.scm format/format.scm
+	csc -O5 swapview.scm
 	strip swapview
 
-.libraries.stamp: libraries.scm
-	chicken-install format loops -deploy -p $$(pwd)
-	touch .libraries.stamp
+format/format.scm:
+	chicken-install -r format 
 
 clean:
 	-rm -f swapview *.so *.setup-info *.o .libraries.stamp
+	-rm -rf format

--- a/Chicken/libraries.scm
+++ b/Chicken/libraries.scm
@@ -1,7 +1,0 @@
-(use srfi-1)
-(use srfi-13)
-(use data-structures)
-(use utils)
-(use posix)
-(require-extension loops)
-(require-extension format)

--- a/Chicken/swapview.scm
+++ b/Chicken/swapview.scm
@@ -33,7 +33,9 @@
     (let* ((port (open-input-file (format #f "/proc/~a/cmdline" pid)))
            (rawcomm (string-map (lambda (x) (if (char=? x #\nul) #\space x))
                                 (read-all port)))
-           (comm (substring rawcomm 0 (string-length rawcomm)))
+           (comm (if (> (string-length rawcomm) 0)
+                     (substring rawcomm 0 (- (string-length rawcomm) 1))
+                     ""))
            (smaps (open-input-file (format #f "/proc/~a/smaps" pid)))
            (s 0.0))
       (begin

--- a/Chicken/swapview.scm
+++ b/Chicken/swapview.scm
@@ -1,48 +1,56 @@
-(include "libraries.scm")
+(use srfi-1 srfi-13 data-structures utils posix)
+
+(include "format/format.scm")
+(import format)
+
+(define-syntax while
+  (syntax-rules ()
+    ((while test body ...)
+     (let loop ()
+       (if test
+           (begin
+             body ...
+             (loop)))))))
 
 (define (filesize size)
   (let* ((units "KMGT")
          (left (abs size))
          (unit -1))
     (begin
-      (do-while
-        (and (> left 1100) (< unit 3))
-        (begin
-          (set! left (/ left 1024))
-          (set! unit (+ 1 unit))))
+      (while (and (> left 1100) (< unit 3))
+        (set! left (/ left 1024))
+        (set! unit (+ 1 unit)))
       (if (= unit -1)
         (format #f "~aB" size)
         (begin
           (if (< size 0)
             (set! left (- left)))
-          (format #f "~,1f~aiB" left (string-copy units unit (+ 1 unit))))))))
+          (format #f "~,1f~aiB" left 
+            (string-copy units unit (+ 1 unit))))))))
 
 (define (getSwapFor pid)
   (condition-case
     (let* ((port (open-input-file (format #f "/proc/~a/cmdline" pid)))
-           (comm (string-trim-right (string-map (lambda (x) (if (char=? x #\nul) #\space x))
-                             (read-all port))))
+           (rawcomm (string-map (lambda (x) (if (char=? x #\nul) #\space x))
+                                (read-all port)))
+           (comm (substring rawcomm 0 (string-length rawcomm)))
            (smaps (open-input-file (format #f "/proc/~a/smaps" pid)))
            (s 0.0))
       (begin
-        (do-forever
-          (let ((line (read-line smaps)))
-            (if (eof-object? line) (exit '())
-              (if (> (string-length line) 5)
-                (if (string=? (substring line 0 5) "Swap:")
-                  (set! s (+ s (string->number (cadr (reverse (string-split line )))))))))))
+        (let ((line (read-line smaps)))
+          (while (not (eof-object? line))
+              (if (string=? (substring line 0 5) "Swap:")
+                (set! s (+ s (string->number (cadr (reverse (string-split line )))))))
+              (set! line (read-line smaps))))
         (list pid (* 1024 s) comm)))
     ((exn file) (list pid 0 ""))))
-
 
 (define (getSwap)
   (sort
     (filter (lambda (x) (> (list-ref x 1) 0))
       (map (lambda (x) (getSwapFor (string->number x)))
         (filter (lambda (x) (string->number x))
-          (directory "/proc")
-        )
-      ))
+          (directory "/proc"))))
     (lambda (a b) (< (list-ref a 1) (list-ref b 1)))))
 
 (define (main)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can (edit and then) run `make` to build all that needs to be built.
 * C
 * C++98
 * C++14
-* Chicken, format and loops (will be installed by `make`)
+* Chicken, format (will be installed by `make`)
 * CommonLisp, sbcl
 * Go
 * Guile, tested with 2.0.11


### PR DESCRIPTION
Fixed #9 and #10 in these two commits.

Chicken version changed to statically include `format` library and removed dependency to `loops`. 
We don't want to install share objects to the system folders and cannot set a path for them if they are installed in a local folder. Therefore by removing dynamic linking, we can run the binary outside the building folder.
