### PR TITLE
Java opt

### DIFF
--- a/Java/Makefile
+++ b/Java/Makefile
@@ -7,4 +7,4 @@ clean:
 	-rm -f SwapView.class
 
 run: SwapView.class
-	java -dsa -Xmixed -XX:CompileThreshold=4096 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+UseAES -XX:+UseSerialGC SwapView
+	java -dsa -Xmixed -XX:CompileThreshold=4096 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+UseSerialGC SwapView

--- a/Java/Makefile
+++ b/Java/Makefile
@@ -1,10 +1,10 @@
 default: SwapView.class
 
 SwapView.class: SwapView.java
-	javac SwapView.java
+	javac -g:none SwapView.java
 
 clean:
 	-rm -f SwapView.class
 
 run: SwapView.class
-	java SwapView
+	java -dsa -Xmixed -XX:CompileThreshold=4096 -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+UseAES -XX:+UseSerialGC SwapView

--- a/Java/SwapView.java
+++ b/Java/SwapView.java
@@ -31,7 +31,9 @@ public class SwapView{
 			String comm = new String(Files.readAllBytes(
 				Paths.get(String.format("/proc/%d/cmdline", pid))),
 				StandardCharsets.UTF_8);
-			comm = comm.replace('\0',' ').substring(0, comm.length() - 1);
+			comm = comm.replace('\0',' ');
+			if(comm.charAt(comm.length() - 1) == ' ')
+				comm = comm.substring(0, comm.length() - 1);
 			double s = 0;
 			for(String l: Files.readAllLines(
 				Paths.get(String.format("/proc/%d/smaps", pid)),

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -57,7 +57,7 @@ cmd = ["./swapview.scm"]
 [item.Haskell]
 
 [item.Java]
-cmd = ["java", "SwapView"]
+cmd = ["java", "-dsa", "-Xmixed", "-XX:CompileThreshold=4096", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:+UseAES", "-XX:+UseSerialGC", "SwapView"]
 
 [item.Lua51]
 cmd = ["lua5.1", "swapview.lua"]

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -57,7 +57,7 @@ cmd = ["./swapview.scm"]
 [item.Haskell]
 
 [item.Java]
-cmd = ["java", "-dsa", "-Xmixed", "-XX:CompileThreshold=4096", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:+UseAES", "-XX:+UseSerialGC", "SwapView"]
+cmd = ["java", "-dsa", "-Xmixed", "-XX:CompileThreshold=4096", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:+UseSerialGC", "SwapView"]
 
 [item.Lua51]
 cmd = ["lua5.1", "swapview.lua"]


### PR DESCRIPTION
- [x] optimzied JVM options
- [x] remove last char of comm only if it is '\0', its output is 100% identical with Python2/C/C++ versions

JVM options should use `-client` mode, but it is not supported (ignored) on 64bit Hostspot JVM. 
- Using `-Xmixed  -XX:CompileThreshold=4096 -XX:+UseSerialGC  -XX:+TieredCompilation -XX:TieredStopAtLevel=1` is similar to what is set by `-client` on 32bit Hostspot JVM
- Using `-dsa` disables assertions in runtime libraries

For reference: http://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
