### PR TITLE
fixing GCC option "--std" to "-std" for all C/C++ versions

### DIFF
--- a/C++14/Makefile
+++ b/C++14/Makefile
@@ -1,8 +1,8 @@
-CPPFLAGS=-O4 -Wall -fno-exceptions -fno-rtti
+CPPFLAGS=-O4 -Wall -fno-exceptions -fno-rtti -std=c++14
 CPPC=g++
 
 swapview: swapview.cpp
-	$(CPPC) --std=c++14 swapview.cpp -o swapview $(CPPFLAGS)
+	$(CPPC) swapview.cpp -o swapview $(CPPFLAGS)
 	strip swapview
 
 clean:

--- a/C++14_boost/Makefile
+++ b/C++14_boost/Makefile
@@ -1,8 +1,8 @@
-CPPFLAGS=-O4 -Wall -lboost_filesystem -lboost_system -fno-rtti
+CPPFLAGS=-O4 -Wall -lboost_filesystem -lboost_system -fno-rtti -std=c++14
 CPPC=g++
 
 swapview: swapview.cpp
-	$(CPPC) --std=c++14 swapview.cpp -o swapview $(CPPFLAGS)
+	$(CPPC) swapview.cpp -o swapview $(CPPFLAGS)
 	strip swapview
 
 clean:

--- a/C++98/Makefile
+++ b/C++98/Makefile
@@ -1,6 +1,6 @@
 all: swapview swapview_omp
 
-CPPFLAGS=-O4 -Wall -fno-exceptions -fno-rtti --std=c++98
+CPPFLAGS=-O4 -Wall -fno-exceptions -fno-rtti -std=c++98
 CPPC=g++
 
 swapview: swapview.cpp

--- a/C/Makefile
+++ b/C/Makefile
@@ -1,8 +1,8 @@
-CFLAGS=-O4 -Wall
+CFLAGS=-O4 -Wall -std=c11 
 CC=gcc
 
 swapview: swapview.c
-	$(CC) --std=c11 swapview.c -o swapview $(CFLAGS)
+	$(CC) swapview.c -o swapview $(CFLAGS)
 	strip swapview
 
 clean:


### PR DESCRIPTION
Wrong command line options for gcc in all C/C++ versions
