### PR TITLE
add Perl version

### DIFF
--- a/Perl/swapview.pl
+++ b/Perl/swapview.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+sub filesize{
+    my ($size) = @_;
+    my $units = "KMGT";
+    my $left = abs($size);
+    my $unit = -1;
+    while($left > 1100 and $unit < 3){
+        $left /= 1024;
+        $unit++;
+    }
+    if($unit == -1){
+        return sprintf('%dB', $size);
+    }else{
+        if($size < 0){
+            $left = - $left; 
+        }
+        return sprintf("%.1f%siB", $left, substr($units, $unit, 1));
+    }
+}
+
+sub getSwapFor{
+    my ($pid) = @_;
+    open FILE,sprintf("/proc/%s/cmdline", $pid) or return ($pid, 0, '');
+    my $comm = join("", <FILE>); 
+    close FILE;
+    substr($comm, length($comm) - 1, 1) eq "\0" and chop($comm);
+    $comm =~ s/\0/ /g;
+    open FILE,sprintf("/proc/%s/smaps", $pid) or return ($pid, 0, '');
+    my $s=0;
+    while(<FILE>){
+        if(/^Swap:/){
+            s/[^0-9]//g;
+            $s += $_;
+        }
+    }
+    close FILE;
+    return (pid => $pid, size => $s * 1024, comm =>$comm);
+}
+
+sub getSwap{
+    my @ret = ();
+    opendir (DIR,'/proc') or die $!;
+    while (readdir(DIR)){
+        if(/^[0-9]+$/){
+            my %s = getSwapFor($_);
+            if($s{size} > 0){
+                push @ret, {%s};
+            }
+        }
+    }
+    my @sort_ret = sort { $a->{size} <=> $b->{size} } @ret;
+    return @sort_ret;
+}
+
+my @result = getSwap();
+printf "%5s %9s %s\n", 'PID', 'SWAP', 'COMMAND';
+my $t = 0;
+for my $i (@result){
+    print sprintf("%5s %9s %s\n", $i->{pid}, filesize($i->{size}), $i->{comm});
+    $t += $i->{size};
+}
+print sprintf("Total: %8s\n", filesize($t));

--- a/Perl/swapview.pl
+++ b/Perl/swapview.pl
@@ -24,12 +24,12 @@ sub filesize{
 
 sub getSwapFor{
     my ($pid) = @_;
-    open FILE,"/proc/$pid/cmdline" or return ($pid, 0, '');
+    open FILE,"/proc/$pid/cmdline" or return (pid=>$pid, size=>0, comm=>'');
     my $comm = join("", <FILE>); 
     close FILE;
     substr($comm, length($comm) - 1, 1) eq "\0" and chop($comm);
     $comm =~ s/\0/ /g;
-    open FILE,"/proc/$pid/smaps" or return ($pid, 0, '');
+    open FILE,"/proc/$pid/smaps" or return (pid=>$pid, size=>0, comm=>'');
     my $s=0;
     while(<FILE>){
         if(/^Swap:/){

--- a/Perl/swapview.pl
+++ b/Perl/swapview.pl
@@ -24,12 +24,12 @@ sub filesize{
 
 sub getSwapFor{
     my ($pid) = @_;
-    open FILE,sprintf("/proc/%s/cmdline", $pid) or return ($pid, 0, '');
+    open FILE,"/proc/$pid/cmdline" or return ($pid, 0, '');
     my $comm = join("", <FILE>); 
     close FILE;
     substr($comm, length($comm) - 1, 1) eq "\0" and chop($comm);
     $comm =~ s/\0/ /g;
-    open FILE,sprintf("/proc/%s/smaps", $pid) or return ($pid, 0, '');
+    open FILE,"/proc/$pid/smaps" or return ($pid, 0, '');
     my $s=0;
     while(<FILE>){
         if(/^Swap:/){

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -94,6 +94,9 @@ cmd = ["./swapview.js"]
 
 [item.OCaml]
 
+[item.Perl]
+cmd = ["./swapview.pl"]
+
 [item.PHP]
 cmd = ["./swapview.php"]
 


### PR DESCRIPTION
First time writing Perl... Need help on optimization.
Current performance:

```
---------Results--------(Diff):  KMinAvg      Min      Avg      Max    Stdev  Cnt
C++98_omp               ( 96%):    54.25    47.77    63.13   138.53    18.72   20
Rust_parallel           (100%):    57.90    56.92    59.01    63.00     1.50   20
C++14_boost             ( 94%):   138.31   137.02   143.77   190.28    13.68   20
C++98                   ( 94%):   139.72   137.60   149.10   189.38    17.29   20
C                       (100%):   141.52   140.54   145.30   164.73     6.30   20
C++14                   ( 94%):   161.84   159.00   170.28   216.30    16.46   20
Rust                    (100%):   194.92   191.94   201.38   247.40    12.00   20
LuaJIT                  (  7%):   208.88   205.18   224.26   258.63    19.18   20
NodeJS                  ( 94%):   220.71   216.19   230.79   266.96    15.92   20
D_llvm                  ( 96%):   228.32   222.69   240.85   290.24    18.11   20
Erlang                  ( 92%):   249.99   241.91   271.09   353.09    29.24   20
NodeJS_async            ( 94%):   253.61   251.31   263.07   294.80    12.91   20
PyPy                    (100%):   253.69   248.67   273.22   432.26    40.71   20
CoffeeScript_parallel   ( 94%):   255.42   251.64   265.71   305.37    14.76   20
Vala                    ( 98%):   255.74   248.74   274.13   317.32    23.37   20
CoffeeScript            ( 94%):   259.74   247.02   302.16   488.06    65.15   20
Lua51                   ( 52%):   265.18   258.22   290.05   324.55    26.58   20
Go                      (  7%):   266.03   255.36   285.06   320.24    21.57   20
Python2                 (100%):   266.59   252.80   279.55   317.64    17.14   20
FreePascal              ( 94%):   269.80   265.57   281.85   335.48    22.02   20
Lua52                   (  7%):   277.63   269.74   297.17   346.45    24.35   20
D                       ( 96%):   284.97   281.02   291.79   332.75    12.64   20
Python3_bytes           (  7%):   306.37   295.54   329.49   365.04    25.66   20
PyPy3_bytes             (  7%):   328.35   322.61   344.25   376.80    18.41   20
Python3                 (100%):   333.37   322.16   341.30   380.29    13.01   20
Perl                    (100%):   384.18   368.09   414.77   639.43    57.46   20
Ruby                    (100%):   409.63   400.25   421.92   459.73    17.06   20
Chicken                 ( 98%):   418.18   405.74   508.29  1162.74   199.15   20
Java                    (100%):   515.16   480.29   540.63   695.21    44.09   20
PyPy3                   (100%):   545.86   528.02   565.29   658.77    31.01   20
CSharp                  ( 98%):   685.21   641.54   720.16   813.64    44.61   20
Julia                   (100%):   793.13   786.12   822.78  1094.72    69.97   20
Bash_parallel           ( 96%):   827.55   814.38   878.02  1056.91    73.03   20
Racket_compiled         ( 98%):   908.99   882.78   925.46   981.68    22.64   20
Racket                  ( 98%):   913.94   904.34   943.03  1085.82    49.40   20
CommonLisp_opt          (  7%):   918.60   904.25   935.64  1006.00    24.18   20
CommonLisp_old          (  7%):   936.98   925.91   960.61  1061.72    34.07   20
OCaml                   (  7%):  1020.43  1010.40  1036.66  1086.66    22.36   20
Guile                   ( 98%):  1468.50  1447.58  1506.74  1599.16    45.61   20
Haskell                 ( 91%):  1565.95  1471.19  1590.59  1631.27    38.28   20
Bash                    ( 96%):  1727.41  1587.31  1865.58  2247.15   180.33   20
Elixir                  ( 92%):  1836.31  1752.31  1990.55  2486.13   208.56   20
```

```
               C++98_omp: top:   55.35, min:   47.54, avg:   60.17, max:   70.23, mdev:    6.24, cnt:  20
           Rust_parallel: top:   61.37, min:   59.49, avg:   63.95, max:   76.77, mdev:    3.73, cnt:  20
                   C++98: top:  145.02, min:  144.05, avg:  150.33, max:  187.47, mdev:    9.81, cnt:  20
             C++14_boost: top:  145.08, min:  144.11, avg:  149.67, max:  185.20, mdev:    9.50, cnt:  20
                       C: top:  149.15, min:  146.92, avg:  156.23, max:  185.98, mdev:   10.41, cnt:  20
                   C++14: top:  167.58, min:  166.71, avg:  171.21, max:  192.57, mdev:    6.70, cnt:  20
                    Rust: top:  208.79, min:  206.78, avg:  217.07, max:  255.30, mdev:   12.90, cnt:  20
                  LuaJIT: top:  219.46, min:  217.25, avg:  228.29, max:  252.02, mdev:   11.97, cnt:  20
                  NodeJS: top:  236.70, min:  230.26, avg:  246.25, max:  273.22, mdev:   12.27, cnt:  20
                  D_llvm: top:  236.93, min:  234.21, avg:  240.88, max:  274.25, mdev:    8.26, cnt:  20
   CoffeeScript_parallel: top:  255.15, min:  250.91, avg:  261.25, max:  278.88, mdev:    7.78, cnt:  20
            CoffeeScript: top:  257.34, min:  248.16, avg:  268.60, max:  320.49, mdev:   16.89, cnt:  20
                  Erlang: top:  263.48, min:  247.81, avg:  274.89, max:  319.33, mdev:   15.61, cnt:  20
                    PyPy: top:  268.10, min:  265.10, avg:  278.18, max:  327.02, mdev:   15.89, cnt:  20
                 Python2: top:  268.71, min:  265.42, avg:  277.25, max:  302.66, mdev:   12.54, cnt:  20
                    Vala: top:  273.23, min:  267.93, avg:  279.00, max:  298.66, mdev:    7.40, cnt:  20
                      Go: top:  273.77, min:  268.17, avg:  282.72, max:  311.37, mdev:   11.00, cnt:  20
                   Lua51: top:  275.91, min:  272.93, avg:  285.37, max:  320.58, mdev:   14.40, cnt:  20
            NodeJS_async: top:  278.54, min:  268.93, avg:  288.01, max:  305.88, mdev:   11.31, cnt:  20
                   Lua52: top:  287.31, min:  279.52, avg:  295.69, max:  316.54, mdev:   10.23, cnt:  20
              FreePascal: top:  292.25, min:  288.87, avg:  301.93, max:  340.45, mdev:   14.14, cnt:  20
                       D: top:  295.92, min:  293.97, avg:  299.73, max:  330.56, mdev:    8.01, cnt:  20
           Python3_bytes: top:  315.57, min:  312.07, avg:  326.46, max:  366.55, mdev:   14.79, cnt:  20
             PyPy3_bytes: top:  338.66, min:  333.13, avg:  349.19, max:  374.00, mdev:   13.44, cnt:  20
                 Python3: top:  349.85, min:  346.71, avg:  360.53, max:  405.77, mdev:   16.83, cnt:  20
                    Perl: top:  396.84, min:  391.61, avg:  408.08, max:  435.81, mdev:   13.62, cnt:  20
                 Chicken: top:  422.12, min:  417.33, avg:  431.55, max:  537.20, mdev:   24.81, cnt:  20
                    Ruby: top:  433.58, min:  429.93, avg:  440.00, max:  465.95, mdev:    9.79, cnt:  20
                    Java: top:  516.89, min:  502.54, avg:  526.48, max:  550.53, mdev:   11.68, cnt:  20
                   PyPy3: top:  530.11, min:  522.87, avg:  540.49, max:  575.20, mdev:   14.45, cnt:  20
                  CSharp: top:  630.93, min:  617.68, avg:  645.27, max:  674.54, mdev:   16.92, cnt:  20
                   Julia: top:  806.63, min:  800.79, avg:  813.41, max:  828.77, mdev:    7.88, cnt:  20
           Bash_parallel: top:  885.72, min:  873.07, avg:  893.91, max:  913.22, mdev:   10.53, cnt:  20
          CommonLisp_opt: top:  951.76, min:  944.11, avg:  960.86, max:  982.50, mdev: 4186.23, cnt:  20
          CommonLisp_old: top:  971.83, min:  965.50, avg:  985.61, max: 1021.81, mdev: 4186.25, cnt:  20
                  Racket: top:  978.13, min:  972.40, avg:  989.01, max: 1015.07, mdev: 4186.24, cnt:  20
         Racket_compiled: top:  980.07, min:  970.98, avg:  994.39, max: 1029.26, mdev: 4186.25, cnt:  20
                   OCaml: top: 1078.72, min: 1070.82, avg: 1093.95, max: 1142.59, mdev: 4186.26, cnt:  20
                   Guile: top: 1536.17, min: 1510.64, avg: 1563.18, max: 1617.31, mdev: 4074.70, cnt:  20
                 Haskell: top: 1642.71, min: 1502.78, avg: 1667.83, max: 1702.01, mdev: 3960.10, cnt:  20
                  Elixir: top: 1814.50, min: 1760.99, avg: 1905.22, max: 2315.78, mdev: 3962.07, cnt:  20
                    Bash: top: 2004.08, min: 1938.25, avg: 2073.08, max: 2236.83, mdev: 3842.41, cnt:  20
```
