### PR TITLE
changed CSharp compiler from mcs to dmcs

### DIFF
--- a/CSharp/Makefile
+++ b/CSharp/Makefile
@@ -4,7 +4,7 @@ MONO=mono-sgen
 default: SwapView.exe.so
 
 SwapView.exe: SwapView.cs
-	mcs -clscheck- -debug- -optimize+ SwapView.cs
+	dmcs -clscheck- -debug- -optimize+ SwapView.cs
 
 SwapView.exe.so: SwapView.exe
 	$(MONO) --aot -O=all,-shared $(MONOFLAGS) SwapView.exe


### PR DESCRIPTION
According to this http://stackoverflow.com/a/8372859 and http://www.mono-project.com/docs/about-mono/languages/csharp/ 
We need .Net4.0 here.
