### PR TITLE
add Tcl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 languages = Haskell Haskell2 OCaml Rust Rust_parallel \
 	    C++98 C++11 C++14 C++14_boost C CSharp D Go Vala \
 	    Nim NodeJS NodeJS_async CoffeeScript CoffeeScript_parallel \
-	    Java Chicken Racket FreePascal Erlang CommonLisp_opt Tcl
+	    Java Chicken Racket FreePascal Erlang CommonLisp_opt
 
 all: $(languages)
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 languages = Haskell Haskell2 OCaml Rust Rust_parallel \
 	    C++98 C++11 C++14 C++14_boost C CSharp D Go Vala \
 	    Nim NodeJS NodeJS_async CoffeeScript CoffeeScript_parallel \
-	    Java Chicken Racket FreePascal Erlang CommonLisp_opt
+	    Java Chicken Racket FreePascal Erlang CommonLisp_opt Tcl
 
 all: $(languages)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can (edit and then) run `make` to build all that needs to be built.
 * Rust, use git version please
 * Scala 2.11.6
 * Vala, requires `glib2` (`libglib-2.0` and `libgio-2.0`)
+* Tcl, >= 8.6
 
 Contributions
 ----

--- a/Tcl/swapview.tcl
+++ b/Tcl/swapview.tcl
@@ -1,0 +1,36 @@
+#/usr/bin/tclsh
+
+proc fileSize {bytes {level 0}} {
+	set units {B K M G}
+	if {$bytes >= 1024 && $level < 3} {
+		return [fileSize [expr $bytes/1024] [expr $level+1]]
+	}
+	return "$bytes[lindex $units $level]"
+}
+
+proc readFile {path} {
+	set fd [open $path]
+	set contents [read $fd]
+	close $fd
+	return $contents
+}
+
+proc getSwapInfo {pid} {
+	# return {pid swap-use cmdline}
+	if {![string is digit $pid]} {error error}
+	set cmdline [readFile "/proc/$pid/cmdline"]
+	foreach l [split [readFile "/proc/$pid/smaps"] "\n"] {
+		if {[scan $l "Swap: %d" swapuse]} break
+	}
+	return [list $pid [expr $swapuse*1024] $cmdline]
+}
+
+set total 0
+puts [format "%5s %9s %s" PID SWAP COMMAND]
+foreach pid [lmap dir [glob /proc/*] {file tail $dir}] {
+	if {![catch {getSwapInfo $pid} info] && [llength $info] == 3 && [lindex $info 1] != 0} {
+		puts [format "%5d %9s %s" [lindex $info 0] [fileSize [lindex $info 1]] [lindex $info 2]]
+		
+	}
+}
+puts [format "Total: %8s" [fileSize $total]]

--- a/Tcl/swapview.tcl
+++ b/Tcl/swapview.tcl
@@ -3,9 +3,9 @@
 proc fileSize {bytes {level 0}} {
 	set units {B KiB MiB GiB}
 	if {$bytes >= 1024 && $level < 3} {
-		return [fileSize [expr $bytes/1024] [expr $level+1]]
+		return [fileSize [expr $bytes/1024.0] [expr $level+1]]
 	}
-	return "$bytes[lindex $units $level]"
+	return [format "%.1lf%s" $bytes [lindex $units $level]]
 }
 
 proc readFile {path} {
@@ -18,20 +18,26 @@ proc readFile {path} {
 proc getSwapInfo {pid} {
 	# return {pid swap-use cmdline}
 	if {![string is digit $pid]} {error error}
-	set cmdline [readFile "/proc/$pid/cmdline"]
+	set cmdline [string range [string map {\0 " "} [readFile "/proc/$pid/cmdline"]] 0 end-1]
 	set fd [open "/proc/$pid/smaps"]
 	while {1} {
-		if {[scan [gets $fd] "Swap: %d" swapuse]} break
+		if {[scan [gets $fd] "Swap: %lld" swapuse]} break
 	}
 	close $fd
 	return [list $pid [expr $swapuse*1024] $cmdline]
 }
 
 set total 0
+set all {}
 puts [format "%5s %9s %s" PID SWAP COMMAND]
 foreach pid [lmap dir [glob /proc/*] {file tail $dir}] {
 	if {![catch {getSwapInfo $pid} info] && [llength $info] == 3 && [lindex $info 1] != 0} {
-		puts [format "%5d %9s %s" [lindex $info 0] [fileSize [lindex $info 1]] [lindex $info 2]]
+		lappend all $info
+		incr total [lindex $info 1]
 	}
+}
+set all [lsort -index 1 $all]
+foreach i $all {
+	puts [format "%5s %9s %s" [lindex $i 0] [fileSize [lindex $i 1]] [lindex $i 2]]
 }
 puts [format "Total: %8s" [fileSize $total]]

--- a/Tcl/swapview.tcl
+++ b/Tcl/swapview.tcl
@@ -1,4 +1,4 @@
-#/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 proc fileSize {bytes {level 0}} {
 	set units {B KiB MiB GiB}

--- a/Tcl/swapview.tcl
+++ b/Tcl/swapview.tcl
@@ -1,7 +1,7 @@
 #/usr/bin/tclsh
 
 proc fileSize {bytes {level 0}} {
-	set units {B K M G}
+	set units {B KiB MiB GiB}
 	if {$bytes >= 1024 && $level < 3} {
 		return [fileSize [expr $bytes/1024] [expr $level+1]]
 	}
@@ -19,9 +19,11 @@ proc getSwapInfo {pid} {
 	# return {pid swap-use cmdline}
 	if {![string is digit $pid]} {error error}
 	set cmdline [readFile "/proc/$pid/cmdline"]
-	foreach l [split [readFile "/proc/$pid/smaps"] "\n"] {
-		if {[scan $l "Swap: %d" swapuse]} break
+	set fd [open "/proc/$pid/smaps"]
+	while {1} {
+		if {[scan [gets $fd] "Swap: %d" swapuse]} break
 	}
+	close $fd
 	return [list $pid [expr $swapuse*1024] $cmdline]
 }
 
@@ -30,7 +32,6 @@ puts [format "%5s %9s %s" PID SWAP COMMAND]
 foreach pid [lmap dir [glob /proc/*] {file tail $dir}] {
 	if {![catch {getSwapInfo $pid} info] && [llength $info] == 3 && [lindex $info 1] != 0} {
 		puts [format "%5d %9s %s" [lindex $info 0] [fileSize [lindex $info 1]] [lindex $info 2]]
-		
 	}
 }
 puts [format "Total: %8s" [fileSize $total]]


### PR DESCRIPTION
a quick'n'dirty implementation.
-    Must be readable and maintainable: I'm not sure, most Tcl code looks like this.
-    Output exact the same format as other versions (but sorting may be unstable): not quite tested
-    Try to be efficient: not really. but it's quite fast (here).
-    Please include a Makefile if appropriate: no need.
-    Don't forget to tell the compiler to optimize: no need.
