### PR TITLE
Swapview Optimazation in C

### DIFF
--- a/C/swapview.c
+++ b/C/swapview.c
@@ -61,8 +61,8 @@ swap_info *getSwapFor(int pid){
   fclose(fd);
 
   for(char *p = comm; p < comm + len - 1; ++p)
-    *p || (*p = ' '); // comm[len-1] is \0 or non-space
-  comm[len]='\0'; // assure string is terminated
+    *p || (*p = ' '); // comm[len-1] is '\n'
+  comm[len - 1]='\0'; // assure string is terminated
 
   assure(snprintf(filename, BUFSIZE, "/proc/%d/smaps", pid) > 0);
   if(!(fd = fopen(filename, "r")))

--- a/C/swapview.c
+++ b/C/swapview.c
@@ -52,7 +52,7 @@ swap_info *getSwapFor(int pid){
   char filename[BUFSIZE];
   FILE *fd = 0;
   size_t size = BUFSIZE;
-  char *comm = malloc(size + 1); // +1 for last \0
+  char *comm = malloc(size);
   char *line;
   ssize_t len=0;
   double s = 0.0;
@@ -60,7 +60,7 @@ swap_info *getSwapFor(int pid){
   assure(snprintf(filename, BUFSIZE, "/proc/%d/cmdline", pid) > 0);
   if(!(fd = fopen(filename, "r")))
     goto err;
-  len = fread(comm, 1, size, fd);
+  len = getline(&comm, &size, fd);
   fclose(fd);
 
   for(char *p = comm; p < comm + len - 1; ++p)

--- a/C/swapview.c
+++ b/C/swapview.c
@@ -3,9 +3,11 @@
 #include<stdlib.h>
 #include<string.h>
 #include<math.h>
-
+#include<ctype.h>
 #include<errno.h>
 #include<error.h>
+#include<fcntl.h>
+#include<unistd.h>
 #include<sys/types.h>
 #include<dirent.h>
 
@@ -16,6 +18,17 @@
 #define TARGETLEN 5
 
 #define assure(exp) if(!(exp)) error(1, errno, "\"%s\" failed in %d", #exp, __LINE__)
+
+typedef struct {
+  int pid;
+  double size;
+  char *comm;
+} swap_info;
+
+static swap_info **infos;
+static size_t info_length;
+static size_t info_size;
+
 
 char *filesize(double size){
   char units[] = "KMGT";
@@ -38,12 +51,6 @@ char *filesize(double size){
   }
   return buf;
 }
-
-typedef struct {
-  int pid;
-  double size;
-  char *comm;
-} swap_info;
 
 swap_info *getSwapFor(int pid){
   char filename[BUFSIZE];
@@ -89,30 +96,24 @@ err:
   return ret;
 }
 
-
 int comp(const void *a, const void *b){
   double r = (*((swap_info **) a))->size - (*((swap_info **) b))->size;
   return (r > 0.0) - (r < 0.0);	// sign of double to int
 }
 
-swap_info **getSwap(){
-  int size = 16;
-  int length = 0;
-
+void getSwap(){
   DIR *dp;
   struct dirent *dirp;
   assure(dp = opendir("/proc"));
 
-  swap_info **ret;
-  assure(ret = malloc(sizeof(swap_info *) * size));
   while((dirp = readdir(dp)) != NULL){
     int pid = atoi(dirp->d_name);
     if(pid > 0){
       swap_info *swapfor = getSwapFor(pid);
       if(swapfor->size > 0){
-        if(length == size)
-          assure(ret = realloc(ret, sizeof(swap_info *) * (size <<= 1)));
-        ret[length++] = swapfor;
+        if(info_length == info_size)
+          assure(infos = realloc(infos, sizeof(swap_info *) * (info_size <<= 1)));
+        infos[info_length++] = swapfor;
       }else{
         free(swapfor->comm);
         free(swapfor);
@@ -121,26 +122,25 @@ swap_info **getSwap(){
   }
   closedir(dp);
 
-  qsort(ret, length, sizeof(swap_info *), comp);
-
-  if(length == size)
-    assure(ret = realloc(ret, sizeof(swap_info *) * (++size)));
-  ret[length] = 0;		// mark for end
-  return ret;
+  qsort(infos, info_length, sizeof(swap_info *), comp);
 }
 
 int main(int argc, char *argv[]){
-  swap_info **infos = getSwap(), **p = infos;
   double total = 0;
+  info_size = 16;
+  assure(infos = malloc(sizeof(swap_info *) * info_size));
+
+  getSwap();
   printf("%5s %9s %s\n", "PID", "SWAP", "COMMAND");
-  for(; *p; ++p){
-    char *size = filesize((*p)->size);
-    printf(FORMAT, (*p)->pid, size, (*p)->comm);
-    total += (*p)->size;
+  for(int i = 0; i < info_length; ++i) {
+    char *size = filesize(infos[i]->size);
+    printf(FORMAT, infos[i]->pid, size, infos[i]->comm);
+    total += infos[i]->size;
     free(size);
-    free((*p)->comm);
-    free(*p);
+    free(infos[i]->comm);
+    free(infos[i]);
   }
+
   free(infos);
   char *stotal = filesize(total);
   printf("Total: %8s\n", stotal);


### PR DESCRIPTION
Key points are as follows:
1. Make swap-info as global static variable to avoid nasty pointer operations passing swap-info between functions and simplify coding style.
2. Eliminate unnecessary malloc/free overhead calling 'getline' function to boost program speed.
