### PR TITLE
Haskell: fix all hlint warnings and errors

### DIFF
--- a/Haskell/swapview.hs
+++ b/Haskell/swapview.hs
@@ -55,7 +55,7 @@ total = sum . map snd
 
 units = "KMGTP"
 
-liftUnit :: Double -> [Char] -> [Char] -> (Double, [Char])
+liftUnit :: Double -> String -> String -> (Double, String)
 liftUnit n u l =
   if n > 1100 && (not.null) u
      then liftUnit (n/1024) (tail u) (head u :l)

--- a/Haskell2/swapview.hs
+++ b/Haskell2/swapview.hs
@@ -25,7 +25,7 @@ filesize n =
   where (m, level) = liftUnit (fromIntegral n) units []
         unit = head level
 
-liftUnit :: Double -> [Char] -> [Char] -> (Double, [Char])
+liftUnit :: Double -> String -> String -> (Double, String)
 liftUnit n u l =
   if n > 1100 && (not.null) u
      then liftUnit (n/1024) (tail u) (head u :l)
@@ -88,6 +88,6 @@ formatResult (pid, size) = do
   return $ format pid size cmd
 
 getCommand :: Pid -> IO T.Text
-getCommand pid = T.init <$> T.map transnul <$> T.readFile (T.unpack $ "/proc/" `T.append` pid `T.append` "/cmdline")
+getCommand pid = T.init . T.map transnul <$> T.readFile (T.unpack $ "/proc/" `T.append` pid `T.append` "/cmdline")
   where transnul ch = if ch == '\0' then ' ' else ch
 


### PR DESCRIPTION
Fix all three issues reported by hlint:

```
Haskell/swapview.hs:58:13: Warning: Use String
Haskell2/swapview.hs:28:13: Warning: Use String
Haskell2/swapview.hs:91:18: Error: Functor law
```
