### PR TITLE
Fix /proc/*/smaps string searches for compatibility with newer kernels

### DIFF
--- a/Bash/swapview.sh
+++ b/Bash/swapview.sh
@@ -28,9 +28,9 @@ getSwap(){
         # assuming awk works faster than read.
         swap=$(
             awk '
-                BEGIN  { total = 0 }
-                /Swap/ { total += $2 }
-                END    { print total }
+                BEGIN   { total = 0 }
+                /Swap:/ { total += $2 }
+                END     { print total }
             ' /proc/$pid/smaps 2>/dev/null
         ) &&
 

--- a/Bash_parallel/swapview.sh
+++ b/Bash_parallel/swapview.sh
@@ -34,9 +34,9 @@ function getSwapFor(){
 
     swap=$(
         awk '
-            BEGIN  { total = 0 }
-            /Swap/ { total += $2 }
-            END    { print total }
+            BEGIN   { total = 0 }
+            /Swap:/ { total += $2 }
+            END     { print total }
         ' /proc/$pid/smaps 2>/dev/null
     )
     [[ $? -ne 0 ]] && return

--- a/CommonLisp_old/swapview.lisp
+++ b/CommonLisp_old/swapview.lisp
@@ -16,7 +16,7 @@
               (if stream
                 (loop for line = (read-line stream nil nil)
                       while line
-		     when (search "Swap" line)
+		     when (search "Swap:" line)
                       summing (parse-integer (subseq line (1+ (position #\: line))) :junk-allowed t)))))))
 		    (if size size 0)))
 

--- a/CommonLisp_opt/swapview.lisp
+++ b/CommonLisp_opt/swapview.lisp
@@ -18,7 +18,7 @@
           (if stream
             (loop for line = (read-line stream nil nil)
                   while line
-                  when (search "Swap" line)
+                  when (search "Swap:" line)
                   summing (parse-integer (subseq line (1+ (position #\: line))) :junk-allowed t))
             0)))
       0))

--- a/POSIX_shell/swapview.sh
+++ b/POSIX_shell/swapview.sh
@@ -21,7 +21,7 @@ EOF
                 [ -r "$smaps_file" ] && \
                 ( [ "$CURRENT_USER_ID" -eq 0 ] || [ -O "$smaps_file" ] )
             then
-                swap_size="$(grep -F 'Swap' "$smaps_file" | \
+                swap_size="$(grep -F 'Swap:' "$smaps_file" | \
                             awk 'BEGIN{ sum = 0 }
                                  { sum += $2 }
                                  END{ print sum }')"

--- a/Perl/swapview.pl
+++ b/Perl/swapview.pl
@@ -20,7 +20,7 @@ sub get_swap_info_from {
         ) {
             open my $smaps_file_fh, '<', $smaps_file;
             while (my $line = <$smaps_file_fh>) {
-                if ( $line =~ /Swap/ ) {
+                if ( $line =~ /Swap:/ ) {
                     $swap_size += ( split( /[[:space:]]+/, $line ) )[1];
                 }
             }


### PR DESCRIPTION
Match "Swap:" lines but not "SwapPss:".

See torvalds/linux@8334b96221ff0dcbde4873d31eb4d84774ed8ed4
