### PR TITLE
Remove regex operations in OCaml

### DIFF
--- a/OCaml/Makefile
+++ b/OCaml/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 %: %.ml
-	ocamlopt str.cmxa $< -o $@
+	ocamlopt -ccopt -O3 -noassert -unsafe $< -o $@
 	strip $@
 
 


### PR DESCRIPTION
Haskell 都没有用 regex，OCaml 也不应该用，这样才公平嘛。
