### PR TITLE
reduce string convert

### DIFF
--- a/Go/swapview_test.go
+++ b/Go/swapview_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkGetInfos(t *testing.B) {
+	t.ResetTimer()
+	for i := 0; i < t.N; i++ {
+		GetInfos()
+	}
+}


### PR DESCRIPTION
At the first sight, I try to avoid some obviously bytes to string type conversion.
But after some bench, I find more then 50% CPU time is spent in syscall, i.e.  
this test can not take advantage of the Go language.
