### PR TITLE
Fix bytes.__index__(...) == b'...'

### DIFF
--- a/Python3_bytes/swapview.py
+++ b/Python3_bytes/swapview.py
@@ -22,7 +22,7 @@ def filesize(size):
 def getSwapFor(pid):
   try:
     comm = open('/proc/%s/cmdline' % pid, 'rb').read()
-    if comm and comm[-1] == b'\x00':
+    if comm.endswith(b'\x00'):
       comm = comm[:-1]
     comm = comm.replace(b'\x00', b' ')
     with open('/proc/%s/smaps' % pid, 'rb') as f:


### PR DESCRIPTION
因为 `bytes.__index__(...) -> int` ，某一行永远不会执行……
修复之后py3的速度应该会再下降一点
