### PR TITLE
fix bug in go version go1.9: fatal error: all goroutines are asleep - deadlock

### DIFF
--- a/Go_goroutine/swapview.go
+++ b/Go_goroutine/swapview.go
@@ -72,6 +72,7 @@ func GetInfos() (list []Info) {
 	for _, name := range names {
 		pid, err := strconv.Atoi(name)
 		if err != nil {
+			wg.Done()
 			continue
 		}
 		go GetInfo(pid, info_ch, wg)


### PR DESCRIPTION
我使用 go1.9 运行 Go_goroutine 下的示例，发现有运行时错误
是由于 continue 上少了 wg.Done() 导致的