### PR TITLE
Fix scale of Bash version

### DIFF
--- a/Bash/swapview.sh
+++ b/Bash/swapview.sh
@@ -13,7 +13,7 @@ filesize(){
     # See also ``base ** pow`` (bash) and ``base ^ pow`` (bc).
 	# Should this be precomputed?
     for ((pos=0, powed=1024; size / powed > 1100 && pos < nunit; pos++, powed *= 1024)); do :; done
-    printf '%.1f%siB\n' "$(bc <<< "$size / ($powed)")" "${unit[pos]}"
+    printf '%.1f%siB\n' "$(bc <<< "scale=1; $size / ($powed)")" "${unit[pos]}"
 }
 
 getSwap(){


### PR DESCRIPTION
This change makes output of the bash version match the other versions. 

Before:
![2019-02-17-103847-95a890](https://user-images.githubusercontent.com/1006477/52907638-555fab00-32a0-11e9-8175-49363132bbc0.png)

After:
![2019-02-17-103855-55626b](https://user-images.githubusercontent.com/1006477/52907639-58f33200-32a0-11e9-8d54-5281110e02f1.png)
