### PR TITLE
Use sprintf-js instead of sprintf

### DIFF
--- a/NodeJS/package.json
+++ b/NodeJS/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "sprintf": ""
+    "sprintf-js": ""
   }
 }

--- a/NodeJS/swapview.js
+++ b/NodeJS/swapview.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const sprintf = require("sprintf")
+const sprintf = require('sprintf-js').sprintf
 const fs = require("fs")
 
 function filesize(size) {

--- a/NodeJS_async/package.json
+++ b/NodeJS_async/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "sprintf": "",
+    "sprintf-js": "",
     "async": ""
   }
 }

--- a/NodeJS_async/swapview.js
+++ b/NodeJS_async/swapview.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var sprintf = require("sprintf");
+var sprintf = require('sprintf-js').sprintf;
 var fs = require("fs");
 var async = require("async");
 

--- a/NodeJS_cluster/package.json
+++ b/NodeJS_cluster/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "sprintf": "^0.1.5"
+    "sprintf-js": ""
   }
 }

--- a/NodeJS_cluster/swapview.js
+++ b/NodeJS_cluster/swapview.js
@@ -9,7 +9,7 @@ if (cluster.isMaster) {
   ////////////////////
 
   const coreCount = require('os').cpus().length;
-  const sprintf = require('sprintf');
+  const sprintf = require('sprintf-js').sprintf;
 
   const filesize = function(size) {
     const units = 'KMGT';


### PR DESCRIPTION
Removes a warning:
```
npm WARN deprecated sprintf@0.1.5: The sprintf package is deprecated in
favor of sprintf-js.
```