### PR TITLE
Crystal: Add concurrent with fiber and parallel with process

### DIFF
--- a/Crystal/.gitignore
+++ b/Crystal/.gitignore
@@ -1,0 +1,4 @@
+lib/
+swapview
+swapview_fiber
+swapview_process

--- a/Crystal/Makefile
+++ b/Crystal/Makefile
@@ -1,12 +1,18 @@
 CRYSTAL_BIN ?= $(shell which crystal)
+SHARDS_BIN ?= $(shell which shards)
 
 .PHONY: all clean
+
+default: all
 
 %: %.cr
 	$(CRYSTAL_BIN) build --release --no-debug $<
 	strip $@
 
-all: swapview swapview_fiber swapview_process
+shard_install:
+	$(SHARDS_BIN) install
+
+all: swapview swapview_fiber shard_install swapview_process
 
 clean:
-	-rm -f swapview swapview_fiber swapview_process
+	-rm -rf swapview{,_fiber,_process} lib/

--- a/Crystal/Makefile
+++ b/Crystal/Makefile
@@ -6,7 +6,7 @@ CRYSTAL_BIN ?= $(shell which crystal)
 	$(CRYSTAL_BIN) build --release --no-debug $<
 	strip $@
 
-all: swapview
+all: swapview swapview_fiber swapview_process
 
 clean:
-	-rm -f swapview
+	-rm -f swapview swapview_fiber swapview_process

--- a/Crystal/common.cr
+++ b/Crystal/common.cr
@@ -60,7 +60,7 @@ module SwapView
       pid, swap, comm = value
       puts FORMAT % [pid, filesize(swap), comm]
     end
-    res = results.map {|x| x[1] }
+    res = results.map { |x| x[1] }
     if res.empty?
       t = 0
     else

--- a/Crystal/common.cr
+++ b/Crystal/common.cr
@@ -1,0 +1,71 @@
+module SwapView
+  extend self
+
+  FORMAT = "%5s %9s %s"
+  TOTALFMT = "Total: %8s"
+  SWAP = "Swap: "
+
+  def filesize(size)
+    units = %w(B KiB MiB GiB TiB)
+    left = size.abs
+    unit = 0
+    num = 0
+    units.each_with_index do |_, i|
+      unit = i
+      num = left / 1024.0 ** i
+      break if num <= 1100 || i == units.size - 1
+    end
+    if unit == 0
+      "#{size}B"
+    else
+      "%.1f%s" % [size < 0 ? -num : num, units[unit]]
+    end
+  end
+
+  def get_pids
+    pids = [] of Int32
+    Dir.entries("/proc").each do |entry|
+      pid = entry.to_i?
+      if pid
+        pids << pid
+      end
+    end
+    pids
+  end
+
+  def get_swap_for(pid)
+    comm = File.read("/proc/#{pid}/cmdline")
+    comm = comm.rchop if comm != "" && comm[-1] == '\0'
+    comm = comm.tr("\0", " ")
+    result = File.read("/proc/#{pid}/smaps").split('\n')
+    result.select! { |l| l.starts_with? SWAP }
+    if result.empty?
+      {pid, 0, nil}
+    else
+      res = result.map { |l| l[6..-3].to_i }
+      s = res.reduce { |acc, i| acc + i }
+      {pid, s * 1024, comm}
+    end
+  rescue ex: Errno
+    if [Errno::EACCES, Errno::ENOENT].includes? ex.errno
+      {pid, 0, nil}
+    else
+      raise ex
+    end
+  end
+
+  def report(results)
+    puts FORMAT % %w(PID SWAP COMMAND)
+    results.each do |value|
+      pid, swap, comm = value
+      puts FORMAT % [pid, filesize(swap), comm]
+    end
+    res = results.map {|x| x[1] }
+    if res.empty?
+      t = 0
+    else
+      t = res.reduce { |acc, i| acc + i }
+    end
+    puts TOTALFMT % filesize(t)
+  end
+end

--- a/Crystal/shard.lock
+++ b/Crystal/shard.lock
@@ -1,0 +1,6 @@
+version: 1.0
+shards:
+  parallel:
+    github: RX14/parallel.cr
+    commit: 7f88d4ce8b0a9cde962a9889abb6a95e6733e860
+

--- a/Crystal/shard.lock
+++ b/Crystal/shard.lock
@@ -1,6 +1,10 @@
 version: 1.0
 shards:
-  parallel:
-    github: RX14/parallel.cr
-    commit: 7f88d4ce8b0a9cde962a9889abb6a95e6733e860
+  msgpack:
+    github: crystal-community/msgpack-crystal
+    version: 0.14.2
+
+  parallel_worker:
+    github: aligo/parallel_worker
+    commit: 9fd802c70a6249daa94cd5d64f62251e5c233605
 

--- a/Crystal/shard.yml
+++ b/Crystal/shard.yml
@@ -1,0 +1,6 @@
+name: swapview
+version: 0.0.1
+
+dependencies:
+  parallel:
+    github: RX14/parallel.cr

--- a/Crystal/shard.yml
+++ b/Crystal/shard.yml
@@ -2,5 +2,5 @@ name: swapview
 version: 0.0.1
 
 dependencies:
-  parallel:
-    github: RX14/parallel.cr
+  parallel_worker:
+    github: aligo/parallel_worker

--- a/Crystal/swapview.cr
+++ b/Crystal/swapview.cr
@@ -2,17 +2,17 @@ require "./common.cr"
 
 module SwapView
   def get_swap
+    pids = get_pids
+
     result = [] of Tuple(Int32, Int32, String | Nil)
-    Dir.entries("/proc").each do |entry|
-      pid = entry.to_i?
-      if pid
-        swap_info = get_swap_for(pid)
-        if swap_info[1] > 0
-          result << swap_info
-        end
+    pids.each do |pid|
+      swap_info = get_swap_for(pid)
+      if swap_info[1] > 0
+        result << swap_info
       end
     end
-    result.sort_by! {|x| x[1] }
+
+    result.sort_by! { |x| x[1] }
     result
   end
 

--- a/Crystal/swapview_fiber.cr
+++ b/Crystal/swapview_fiber.cr
@@ -3,14 +3,21 @@ require "./common.cr"
 module SwapView
   def get_swap
     pids = get_pids
-    outputs = parallel(
-      pids.each {|pid| get_swap_for(pid) }
-    )
 
-    result = [] of Tuple(Int32, Int32, String | Nil)
-    outputs.each do |output|
-      if output && output[1] > 0
-        result << output
+    channel = Channel(Tuple(Int32, Int32, String | Nil)).new(pids.size)
+
+    pids.each do |pid|
+      spawn do
+        swap_info = get_swap_for(pid)
+        channel.send(swap_info)
+      end
+    end
+
+    result = [] of {Int32, Int32, String | Nil}
+    pids.size.times do
+      swap_info = channel.receive
+      if swap_info && swap_info[1] > 0
+        result << swap_info
       end
     end
     result.sort_by! {|x| x[1] }

--- a/Crystal/swapview_fiber.cr
+++ b/Crystal/swapview_fiber.cr
@@ -20,7 +20,8 @@ module SwapView
         result << swap_info
       end
     end
-    result.sort_by! {|x| x[1] }
+
+    result.sort_by! { |x| x[1] }
     result
   end
 

--- a/Crystal/swapview_fiber.cr
+++ b/Crystal/swapview_fiber.cr
@@ -2,14 +2,15 @@ require "./common.cr"
 
 module SwapView
   def get_swap
+    pids = get_pids
+    outputs = parallel(
+      pids.each {|pid| get_swap_for(pid) }
+    )
+
     result = [] of Tuple(Int32, Int32, String | Nil)
-    Dir.entries("/proc").each do |entry|
-      pid = entry.to_i?
-      if pid
-        swap_info = get_swap_for(pid)
-        if swap_info[1] > 0
-          result << swap_info
-        end
+    outputs.each do |output|
+      if output && output[1] > 0
+        result << output
       end
     end
     result.sort_by! {|x| x[1] }

--- a/Crystal/swapview_process.cr
+++ b/Crystal/swapview_process.cr
@@ -1,30 +1,47 @@
 require "json"
 require "system"
+
+require "parallel"
 require "./common.cr"
 
-CPU_COUNT = System.cpu_count
-
 module SwapView
+  def worker(in_channel, out_channel)
+    loop do
+      pid = in_channel.receive
+      swap_info = get_swap_for(pid)
+      # FIXME It is hard to share non-value types at the moment.
+      # So we just drop the third element (cmd, String type).
+      # See: Serialization for non-value types #5 https://github.com/RX14/parallel.cr/issues/5 .
+      # And https://crystal-lang.org/api/0.28.0/Value.html .
+      output = {swap_info[0], swap_info[1]}
+      out_channel.send(output)
+    end
+  end
+
   def get_swap
     pids = get_pids
 
-    processes = pids.map {|pid| Process.fork {
-      swap_info = get_swap_for(pid)
-      puts swap_info.to_json
-    }}
-    processes.each {|process| process.wait }
-    result = [] of {Int32, Int32, String | Nil}
-    processes.each do |process|
-      op = process.output?
-      next if !op
-      output = JSON.parse(op)
-      size = output[1].as_i
-      if size > 0
-        result << {output[0].as_i, size, output[2].as_s?}
+    job_channel = PChan(Int32).new
+    results_channel = PChan(Tuple(Int32, Int32)).new
+
+    System.cpu_count.times do
+      pspawn { worker(job_channel, results_channel) }
+    end
+
+    spawn do
+      pids.each { |pid| job_channel.send pid }
+    end
+
+    result = [] of {Int32, Int32, Nil}
+    pids.size.times do
+      swap_info = results_channel.receive
+      next if !swap_info
+      if swap_info[1] > 0
+        result << {swap_info[0], swap_info[1], nil}
       end
     end
 
-    result.sort_by! {|x| x[1] }
+    result.sort_by! { |x| x[1] }
     result
   end
 

--- a/Crystal/swapview_process.cr
+++ b/Crystal/swapview_process.cr
@@ -1,45 +1,18 @@
-require "json"
 require "system"
 
-require "parallel"
+require "parallel_worker"
 require "./common.cr"
 
 module SwapView
-  def worker(in_channel, out_channel)
-    loop do
-      pid = in_channel.receive
-      swap_info = get_swap_for(pid)
-      # FIXME It is hard to share non-value types at the moment.
-      # So we just drop the third element (cmd, String type).
-      # See: Serialization for non-value types #5 https://github.com/RX14/parallel.cr/issues/5 .
-      # And https://crystal-lang.org/api/0.28.0/Value.html .
-      output = {swap_info[0], swap_info[1]}
-      out_channel.send(output)
-    end
-  end
-
   def get_swap
     pids = get_pids
 
-    job_channel = PChan(Int32).new
-    results_channel = PChan(Tuple(Int32, Int32)).new
-
-    System.cpu_count.times do
-      pspawn { worker(job_channel, results_channel) }
+    worker = ParallelWorker::Process(Int32, Tuple(Int32, Int32, String | Nil)).new(System.cpu_count.to_i32) do |pid|
+      get_swap_for(pid)
     end
 
-    spawn do
-      pids.each { |pid| job_channel.send pid }
-    end
-
-    result = [] of {Int32, Int32, Nil}
-    pids.size.times do
-      swap_info = results_channel.receive
-      next if !swap_info
-      if swap_info[1] > 0
-        result << {swap_info[0], swap_info[1], nil}
-      end
-    end
+    result = worker.perform_all(pids)
+    result.select!  { |swap_info| swap_info && swap_info[1] > 0 }
 
     result.sort_by! { |x| x[1] }
     result

--- a/Crystal/swapview_process.cr
+++ b/Crystal/swapview_process.cr
@@ -1,0 +1,37 @@
+require "json"
+require "system"
+require "./common.cr"
+
+CPU_COUNT = System.cpu_count
+
+module SwapView
+  def get_swap
+    pids = get_pids
+
+    processes = pids.map {|pid| Process.fork {
+      swap_info = get_swap_for(pid)
+      puts swap_info.to_json
+    }}
+    processes.each {|process| process.wait }
+    result = [] of {Int32, Int32, String | Nil}
+    processes.each do |process|
+      op = process.output?
+      next if !op
+      output = JSON.parse(op)
+      size = output[1].as_i
+      if size > 0
+        result << {output[0].as_i, size, output[2].as_s?}
+      end
+    end
+
+    result.sort_by! {|x| x[1] }
+    result
+  end
+
+  def main
+    results = get_swap
+    report(results)
+  end
+end
+
+SwapView.main

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -49,6 +49,14 @@ dir = "C++98"
 
 [item.Crystal]
 
+[item.Crystal_fiber]
+cmd = ["./swapview_fiber"]
+dir = "Crystal"
+
+[item.Crystal_process]
+cmd = ["./swapview_process"]
+dir = "Crystal"
+
 [item.CSharp]
 cmd = ["mono-sgen", "--desktop", "SwapView.exe"]
 


### PR DESCRIPTION
Tested with Crystal 0.28.0, Go 1.12.4 and Rust 1.34.2 on Arch Linux:

```
$ ./run_benchmark Crystal Crystal_fiber Crystal_process Go Go_goroutine Rust Rust_parallel <benchmark.toml 
Running Crystal...Ok(BenchmarkResult { topavg: 401418467, avg: 410131432, min: 390746809, max: 446683122, mdev: 12055625, count: 20 })
Running Crystal_fiber...Ok(BenchmarkResult { topavg: 398157371, avg: 408922979, min: 394555717, max: 490207292, mdev: 20431973, count: 20 })
Running Crystal_process...Ok(BenchmarkResult { topavg: 227214601, avg: 242445906, min: 223599058, max: 298057674, mdev: 22701522, count: 20 })
Running Go...Ok(BenchmarkResult { topavg: 384300686, avg: 394494455, min: 373100521, max: 413759685, mdev: 11953877, count: 20 })
Running Go_goroutine...Ok(BenchmarkResult { topavg: 167479977, avg: 172445711, min: 163489879, max: 195793858, mdev: 6916480, count: 20 })
Running Rust...Ok(BenchmarkResult { topavg: 316342107, avg: 321359432, min: 313524414, max: 331637328, mdev: 5795396, count: 20 })
Running Rust_parallel...Ok(BenchmarkResult { topavg: 148730917, avg: 151004489, min: 147642895, max: 158154243, mdev: 3417801, count: 20 })
           Rust_parallel: top:  148.73, min:  147.64, avg:  151.00, max:  158.15, mdev:    3.42, cnt:  20
            Go_goroutine: top:  167.48, min:  163.49, avg:  172.45, max:  195.79, mdev:    6.92, cnt:  20
         Crystal_process: top:  227.21, min:  223.60, avg:  242.45, max:  298.06, mdev:   22.70, cnt:  20
                    Rust: top:  316.34, min:  313.52, avg:  321.36, max:  331.64, mdev:    5.80, cnt:  20
                      Go: top:  384.30, min:  373.10, avg:  394.49, max:  413.76, mdev:   11.95, cnt:  20
           Crystal_fiber: top:  398.16, min:  394.56, avg:  408.92, max:  490.21, mdev:   20.43, cnt:  20
                 Crystal: top:  401.42, min:  390.75, avg:  410.13, max:  446.68, mdev:   12.06, cnt:  20
```