### PR TITLE
C: Use clang-format LLVM

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle:  LLVM
+---


### PR DESCRIPTION
There are quite a few... strange aesthetic choices that went into the code. It seems to make reading it harder.

The LLVM style mostly agrees with the C++17 code. Its default indent matches C, and that is why it was chosen. I don't think there is a lot of point in formatting the other C++ stuff yet; although there are bad stuff like `for(` it's nowhere as unreadable as the dense, boilerplatey C. I am not here to make 500 lines of useless diffs yet.

I also changed the C comparison function since the compiler is never doing anything sma rt with the zero check. The direct comparison actually saves a subtraction on ASM :)