### PR TITLE
c++: buffer iostream harder

### DIFF
--- a/C++11/swapview.cc
+++ b/C++11/swapview.cc
@@ -104,6 +104,7 @@ SwapInfo get_swap_info(std::string const & pid){
 }
 
 int main(){
+    std::ios::sync_with_stdio(false);
     std::vector<SwapInfo> all_swap_info;
     for(auto const & n : read_dir("/proc/")){
         if(n[0] == '.')

--- a/C++14/swapview.cpp
+++ b/C++14/swapview.cpp
@@ -76,15 +76,16 @@ vector<swap_info> getSwap(){
 }
 
 int main(int argc, char * argv[]){
+    std::ios::sync_with_stdio(false);
     double t=0.0;
-    cout << setw(5) << "PID" << ' ' << setw(9) << "SWAP" << ' ' << "COMMAND" << endl;
+    cout << setw(5) << "PID" << ' ' << setw(9) << "SWAP" << ' ' << "COMMAND" << "\n";
     for(auto const& item: getSwap()){
         cout << setw(5) << get<0>(item) 
              << ' ' << setw(9) << filesize(get<1>(item))
              << ' ' << get<2>(item)
-             << endl;
+             << "\n";
         t+=get<1>(item);
     }
-    cout<<"Total:"<<setw(9)<<filesize(t)<<endl;
+    cout<<"Total:"<<setw(9)<<filesize(t)<<"\n";
     return 0;
 }

--- a/C++14_boost/swapview.cpp
+++ b/C++14_boost/swapview.cpp
@@ -57,13 +57,14 @@ vector<swap_info> getSwap() {
 }
 
 int main(int argc, char * argv[]){
+    std::ios::sync_with_stdio(false);
     boost::format format("%|5| %|9| %||");
-    cout << format % "PID" % "SWAP" % "COMMAND" << endl;
+    cout << format % "PID" % "SWAP" % "COMMAND" << "\n";
     double t=0.0;
     for(auto const& item: getSwap()){
-        cout << format % get<0>(item) % filesize(get<1>(item)) % get<2>(item) << endl;
+        cout << format % get<0>(item) % filesize(get<1>(item)) % get<2>(item) << "\n";
         t+=get<1>(item);
     }
-    cout<< boost::format("Total:%|9|") % filesize(t)<<endl;
+    cout<< boost::format("Total:%|9|") % filesize(t)<<"\n";
     return 0;
 }

--- a/C++17/swapview.cpp
+++ b/C++17/swapview.cpp
@@ -14,15 +14,15 @@ auto starts_with(const std::string &self, const std::string &prefix) -> bool {
 }
 
 auto filesize(double size) -> std::string {
-    constexpr char units[]{"KMGT"};
-    int unit = -1;
-    for (; size > 1100 && unit < 3; ++unit) size /= 1024;
-    if (unit == -1)
-      return std::to_string(static_cast<size_t>(size)) + 'B';
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1)
-        << size << units[unit] << "iB";
-    return oss.str();
+  constexpr char units[]{"KMGT"};
+  int unit = -1;
+  for (; size > 1100 && unit < 3; ++unit) size /= 1024;
+  if (unit == -1)
+    return std::to_string(static_cast<size_t>(size)) + 'B';
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(1)
+      << size << units[unit] << "iB";
+  return oss.str();
 }
 
 auto get_comm_for(const std::filesystem::path &p) -> std::string {
@@ -57,6 +57,7 @@ auto get_swap() -> std::vector<swap_info> {
 }
 
 int main() {
+  std::ios::sync_with_stdio(false);
   std::cout << std::setw(5) << "PID" << ' '
             << std::setw(9) << "SWAP" << ' '
             << std::setw(0) << "COMMAND" << '\n';
@@ -67,5 +68,5 @@ int main() {
               << std::setw(0) << cmd << '\n';
     total += swp;
   }
-  std::cout << "Total:" << std::setw(9) << filesize(total) << std::endl;
+  std::cout << "Total:" << std::setw(9) << filesize(total) << std::"\n";
 }

--- a/C++98/swapview.cpp
+++ b/C++98/swapview.cpp
@@ -129,6 +129,7 @@ int main(int argc, char * argv[]){
 #ifdef USE_OMP
     omp_set_num_threads(omp_get_num_procs()*4);
 #endif
+    std::ios::sync_with_stdio(false);
     double t=0.0;
     vector<swap_info> result = getSwap();
     format_print("PID", "SWAP", "COMMAND");
@@ -136,6 +137,6 @@ int main(int argc, char * argv[]){
         format_print(*itr);
         t += itr->size;
     }
-    cout<<"Total:"<<setw(9)<<filesize(t)<<endl;
+    cout<<"Total:"<<setw(9)<<filesize(t)<<"\n";
     return 0;
 }


### PR DESCRIPTION
Competitive ricers LOVE this one trick to speed up their iostream. Current \*nix compilers are quite smart with optimizing the heck out of C formatter functions (e.g. replacing printf with puts), but with C++ iostream they don't seem to do anything like that.