### PR TITLE
chicken: query chicken repository instead of hard-coding

### DIFF
--- a/Chicken/Makefile
+++ b/Chicken/Makefile
@@ -1,7 +1,7 @@
 default: swapview
 
 CHICKEN_INSTALL_REPOSITORY:=$(shell pwd)/deps
-CHICKEN_REPOSITORY_PATH:=$(shell pwd)/deps:/usr/lib/chicken/9
+CHICKEN_REPOSITORY_PATH:=$(shell pwd)/deps:$(shell chicken-install -repository)
 export CHICKEN_INSTALL_REPOSITORY
 export CHICKEN_REPOSITORY_PATH
 


### PR DESCRIPTION
may need to perform `chicken-install -purge` once to cleanup local cache in `$HOME/.cache/chicken-install`