### PR TITLE
Rust: Use Vec<u8> instead of String

### DIFF
--- a/Rust/swapview.rs
+++ b/Rust/swapview.rs
@@ -1,5 +1,5 @@
 use std::fs::{File,read_dir};
-use std::io::{Read,BufReader,BufRead};
+use std::io::{Read,BufReader};
 
 const UNITS: [char; 4] = ['K', 'M', 'G', 'T'];
 
@@ -51,15 +51,19 @@ fn get_swap_for(pid: usize) -> isize {
     Ok(f) => f,
     Err(_) => return 0,
   };
-  let reader = BufReader::new(file);
+  let mut reader = BufReader::new(file);
 
-  for l in reader.lines() {
-    let line = match l {
-      Ok(s) => s,
-      Err(_) => return 0,
-    };
-    if line.starts_with("Swap:") {
-      s += line.split_whitespace().nth(1).unwrap().parse::<isize>().unwrap();
+  let mut vec = vec![];
+  reader.read_to_end(&mut vec).unwrap();
+  for line in vec.split(|&c| c == b'\n') {
+    if line.starts_with(b"Swap:") {
+      let string = line[5..]
+        .iter()
+        .skip_while(|&&c| c == b' ')
+        .take_while(|&&c| c != b' ')
+        .map(|&c| c as char)
+        .collect::<String>();
+      s += string.parse::<isize>().unwrap();
     }
   }
   s * 1024


### PR DESCRIPTION
There is no need to use `String` here because it doesn't need to handle with UTF-8 text.

( BTW, I suggest formatting the rust code with `rustfmt`.

**Before**

```
    C++98_omp: top:   82.73, min:   79.20, avg:   87.43, max:  105.61, mdev:    6.41, cnt:  20
Rust_parallel: top:   95.32, min:   94.08, avg:   98.42, max:  111.41, mdev:    4.18, cnt:  20
        C++98: top:  170.72, min:  168.93, avg:  173.83, max:  182.70, mdev:    3.76, cnt:  20
  C++14_boost: top:  172.58, min:  170.67, avg:  180.63, max:  239.08, mdev:   14.53, cnt:  20
        C++17: top:  173.47, min:  171.96, avg:  176.69, max:  186.13, mdev:    3.74, cnt:  20
        C++14: top:  174.28, min:  171.19, avg:  183.63, max:  252.61, mdev:   21.38, cnt:  20
         Rust: top:  198.10, min:  196.08, avg:  201.74, max:  211.39, mdev:    4.52, cnt:  20
            C: top:  198.58, min:  196.73, avg:  203.29, max:  222.99, mdev:    6.34, cnt:  20
        C++11: top:  213.94, min:  209.16, avg:  237.94, max:  416.80, mdev:   55.03, cnt:  20
```

**After**
```
Rust_parallel: top:   79.45, min:   78.25, avg:   83.44, max:   94.88, mdev:    5.35, cnt:  20
    C++98_omp: top:   82.37, min:   78.13, avg:   87.86, max:  113.53, mdev:    7.93, cnt:  20
        C++98: top:  170.59, min:  169.05, avg:  175.21, max:  184.32, mdev:    5.04, cnt:  20
  C++14_boost: top:  171.42, min:  170.71, avg:  176.53, max:  190.11, mdev:    6.00, cnt:  20
         Rust: top:  172.00, min:  171.09, avg:  176.22, max:  188.22, mdev:    5.35, cnt:  20
        C++14: top:  172.30, min:  171.25, avg:  176.92, max:  189.03, mdev:    5.71, cnt:  20
        C++17: top:  173.76, min:  172.32, avg:  178.25, max:  191.65, mdev:    5.40, cnt:  20
            C: top:  199.71, min:  197.93, avg:  204.85, max:  219.96, mdev:    6.42, cnt:  20
        C++11: top:  210.57, min:  208.94, avg:  215.75, max:  234.08, mdev:    6.41, cnt:  20
```