### PR TITLE
C: use fgets instead of getline to avoid too many malloc

### DIFF
--- a/C/swapview.c
+++ b/C/swapview.c
@@ -6,6 +6,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <sys/types.h>
 
 #define FORMAT "%7d %9s %s\n"
@@ -80,14 +81,11 @@ swap_info *getSwapFor(int pid) {
   assure(snprintf(filename, BUFSIZE, "/proc/%d/smaps", pid) > 0);
   if (!(fd = fopen(filename, "r")))
     goto err;
-  char *line;
-  for (line = 0, size = 0;
-       (len = getline(&line, &size, fd)) >= 0;
-       free(line), line = 0, size = 0) {
+  char line[PATH_MAX];
+  while (fgets(line, PATH_MAX, fd) != NULL) {
     if (strncmp(line, TARGET, TARGETLEN) == 0)
       s += atoi(line + TARGETLEN);
   }
-  free(line); // need to free when getline fail, see getline(3)
 err:
   if (fd)
     fclose(fd);


### PR DESCRIPTION
**Before**
```
           Rust_parallel: top:   93.77, min:   92.23, avg:   97.14, max:  109.26, mdev:    4.37, cnt:  20
               C++98_omp: top:  104.29, min:   97.38, avg:  111.92, max:  140.07, mdev:    9.91, cnt:  20
                    Rust: top:  195.17, min:  191.04, avg:  199.71, max:  213.72, mdev:    5.95, cnt:  20
                   C++98: top:  200.64, min:  192.62, avg:  208.63, max:  244.92, mdev:   11.13, cnt:  20
             C++14_boost: top:  201.29, min:  198.10, avg:  207.33, max:  220.67, mdev:    7.02, cnt:  20
                   C++14: top:  201.80, min:  195.46, avg:  206.82, max:  217.70, mdev:    6.22, cnt:  20
                   C++17: top:  203.03, min:  198.89, avg:  209.28, max:  238.98, mdev:    8.84, cnt:  20
                       C: top:  230.49, min:  225.03, avg:  236.83, max:  259.29, mdev:    8.03, cnt:  20
                   C++11: top:  245.76, min:  243.74, avg:  253.32, max:  275.67, mdev:    9.39, cnt:  20
```

**After**
```
           Rust_parallel: top:   93.60, min:   92.14, avg:   96.35, max:  110.39, mdev:    4.48, cnt:  20
               C++98_omp: top:   99.75, min:   94.11, avg:  106.11, max:  126.67, mdev:    8.01, cnt:  20
                    Rust: top:  191.00, min:  188.27, avg:  197.29, max:  219.72, mdev:    8.35, cnt:  20
                       C: top:  194.16, min:  188.03, avg:  202.09, max:  260.18, mdev:   15.03, cnt:  20
                   C++98: top:  199.61, min:  197.47, avg:  205.17, max:  219.50, mdev:    6.81, cnt:  20
                   C++14: top:  200.93, min:  196.14, avg:  206.96, max:  228.75, mdev:    8.50, cnt:  20
                   C++17: top:  202.38, min:  196.43, avg:  207.28, max:  218.82, mdev:    6.17, cnt:  20
             C++14_boost: top:  203.76, min:  198.40, avg:  211.87, max:  255.38, mdev:   13.33, cnt:  20
                   C++11: top:  247.94, min:  239.24, avg:  253.55, max:  272.51, mdev:    7.54, cnt:  20
```