### PR TITLE
enable ChezScheme and be compatible with AUR chez-scheme package

### DIFF
--- a/ChezScheme/Makefile
+++ b/ChezScheme/Makefile
@@ -1,10 +1,10 @@
 default: swapview.so
 
 swapview.so: swapview.ss
-	echo '(compile-program "swapview.ss")' | chez-scheme -q --optimize-level 3
+	echo '(compile-program "swapview.ss")' | scheme -q --optimize-level 3
 
 run: swapview.so
-	chez-scheme --program swapview.so
+	scheme --program swapview.so
 
 clean:
 	-rm -f swapview.so

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ languages = C C++11 C++14 C++14_boost C++17 C++98 \
 		Go Go_goroutine \
 		Java Nim NodeJS NodeJS_async NodeJS_cluster \
 		OCaml Racket Rust Rust_parallel \
-		Scala Vala \
-		# ChezScheme OCaml_lwt
+		Scala Vala ChezScheme
+		# OCaml_lwt
 
 all: $(languages)
 

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -61,7 +61,7 @@ dir = "Crystal"
 cmd = ["mono-sgen", "--desktop", "SwapView.exe"]
 
 [item.ChezScheme]
-cmd = ["chez-scheme", "--program", "swapview.so"]
+cmd = ["scheme", "--program", "swapview.so"]
 
 [item.Chicken]
 


### PR DESCRIPTION
Current result:
```
           Rust_parallel: top:   88.75, min:   87.40, avg:   94.28, max:  151.64, mdev:   14.64, cnt:  20
               C++98_omp: top:   98.72, min:   89.38, avg:  108.19, max:  160.32, mdev:   14.88, cnt:  20
                   C++98: top:  344.20, min:  335.04, avg:  355.14, max:  397.70, mdev:   16.86, cnt:  20
                       C: top:  367.98, min:  359.88, avg:  381.74, max:  452.05, mdev:   21.09, cnt:  20
                    Rust: top:  386.16, min:  371.47, avg:  408.76, max:  466.48, mdev:   25.99, cnt:  20
              ChezScheme: top:  977.38, min:  953.22, avg: 1021.37, max: 1225.94, mdev: 4186.67, cnt:  20
                 Chicken: top: 1170.54, min: 1134.79, avg: 1232.10, max: 1440.03, mdev: 4186.97, cnt:  20
```