### PR TITLE
Fix some types in Cython version

### DIFF
--- a/Cython/swapview.pyx
+++ b/Cython/swapview.pyx
@@ -24,7 +24,7 @@ cdef int find_size(char *s):
   s_tmp[0] = 0
   return atoi(s)
 
-def filesize(int size):
+def filesize(size_t size):
   cdef int unit
   cdef float left
 
@@ -46,6 +46,7 @@ def getSwapFor(int pid):
   cdef char * line = NULL
   cdef size_t l = 0
   cdef FILE* cfile
+  cdef ssize_t read
 
   try:
     comm = open('/proc/%d/cmdline' % pid).read()


### PR DESCRIPTION
The change to `filesize()`'s argument fixes the following OverflowError:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "swapview.pyx", line 91, in init swapview
    main()
  File "swapview.pyx", line 88, in swapview.main
    t = filesize(sum(x[1] for x in results))
  File "swapview.pyx", line 27, in swapview.filesize
    def filesize(int size):
OverflowError: value too large to convert to int
```

The declaration of `read` fixes the following warning:
```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -I/usr/include/python3.9 -c swapview.c -o build/temp.linux-x86_64-3.9/swapview.o
swapview.c: In function ‘__pyx_pf_8swapview_2getSwapFor’:
swapview.c:2261:36: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
 2261 |         __pyx_t_7 = ((__pyx_v_read == -1L) != 0);
      |                                    ^~
```