### PR TITLE
Haskell{,_parallel}: use bytestring instead of text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 erl_crash.dump
 node_modules/
 .cabal-sandbox/
+.stack-work/
 dist/
 cabal.sandbox.config
 packages/

--- a/Haskell/Makefile
+++ b/Haskell/Makefile
@@ -2,19 +2,11 @@ all: swapview
 
 .PHONY: all clean deps cleandeps
 
-swapview: .cabal-sandbox/.timestamp swapview.hs
-	cabal v1-install --reinstall --ghc-options -dynamic
-	strip .cabal-sandbox/bin/swapview
-	ln -sf .cabal-sandbox/bin/swapview swapview
-
-deps: .cabal-sandbox/.timestamp
-
-.cabal-sandbox/.timestamp:
-	cabal v1-sandbox init && cabal v1-install --only-dependencies && touch .cabal-sandbox/.timestamp
+swapview: swapview.hs
+	stack build
+	ln -sfr $$(stack path --local-install-root)/bin/swapview
+	strip swapview
 
 clean:
-	-rm -f *.o *.hi swapview .cabal-sandbox/bin/swapview .cabal-sandbox/.timestamp
-
-cleandeps: clean
-	-cabal sandbox delete
-	-rm -fr dist
+	stack clean
+	rm swapview

--- a/Haskell/stack.yaml
+++ b/Haskell/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-13.26
+packages:
+- .

--- a/Haskell/swapview.cabal
+++ b/Haskell/swapview.cabal
@@ -4,7 +4,7 @@ Cabal-Version:  >= 1.2
 Build-Type:     Simple
 
 Executable swapview
-  Build-Depends:  base, directory, text
+  Build-Depends:  base, directory, bytestring
   Main-Is:        swapview.hs
   Hs-Source-Dirs: .
   GHC-Options: -O2

--- a/Haskell/swapview.hs
+++ b/Haskell/swapview.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, Strict #-}
+{-# LANGUAGE OverloadedStrings, Strict, TypeApplications #-}
 import Control.Applicative ((<$>))
 import Control.Exception (catch, SomeException)
 import Control.Monad (mapM, liftM2)
@@ -7,10 +7,8 @@ import Data.List (sortBy)
 import Data.Function (on)
 import System.Directory (getDirectoryContents)
 import Text.Printf (printf)
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
-import Data.Text (Text, isPrefixOf)
-import Data.Text.Read (decimal)
+import Data.ByteString.Lazy.Char8 (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as BS
 import Data.Either (fromRight)
 
 type Pid = Int
@@ -18,14 +16,14 @@ type Pid = Int
 format = "%7d %9s %s"
 formatHead = "%7s %9s %s"
 totalFmt = "Total: %10s"
-firstLine = printf formatHead ("PID" :: Text) ("SWAP" :: Text) ("COMMAND" :: Text)
+firstLine = printf formatHead ("PID" :: String) ("SWAP" :: String) ("COMMAND" :: String)
 
 main = do
   d <- mapM swapusedWithPid =<< pids
   let printResult r = do
         putStrLn firstLine
-        TIO.putStr . T.unlines $ r
-        putStrLn $ printf totalFmt $ filesize $ (* 1024) $ total d
+        BS.putStr . BS.unlines $ r
+        putStrLn $ printf totalFmt $ BS.unpack . filesize $ (* 1024) $ total d
   printResult =<< mapM formatResult (transformData d)
     where swapused' p = swapused p `catch` handler
           handler :: SomeException -> IO Int
@@ -36,23 +34,23 @@ pids :: IO [Pid]
 pids = map read . filter (all isDigit) <$> getDirectoryContents "/proc"
 
 swapused :: Pid -> IO Int
-swapused pid = sum . map getNumber . filter (isPrefixOf "Swap:") . T.lines <$> TIO.readFile ("/proc/" ++ show pid ++ "/smaps")
-  where getNumber = fst . fromRight undefined . decimal . T.dropWhile (not . isDigit)
+swapused pid = sum . map getNumber . filter (BS.isPrefixOf "Swap:") . BS.lines <$> BS.readFile ("/proc/" ++ show pid ++ "/smaps")
+  where getNumber = (read @Int) . BS.unpack . BS.takeWhile isDigit . BS.dropWhile (not . isDigit)
 
-transformData :: [(Pid, Int)] -> [(Pid, Text)]
+transformData :: [(Pid, Int)] -> [(Pid, ByteString)]
 transformData = map (mapSnd humanSize) . sortBy (compare `on` snd) . filter ((/=) 0 . snd)
   where humanSize = filesize . (* 1024)
 
-formatResult :: (Pid, Text) -> IO Text
+formatResult :: (Pid, ByteString) -> IO ByteString
 formatResult (pid, size) = do
   cmd <- getCommand pid
-  return . T.pack $ printf format pid size cmd
+  return . BS.pack $ printf format pid (BS.unpack size) (BS.unpack cmd)
 
-getCommand :: Pid -> IO Text
-getCommand pid = T.map transnul . dropLastNull <$> TIO.readFile ("/proc/" ++ show pid ++ "/cmdline")
+getCommand :: Pid -> IO ByteString
+getCommand pid = BS.map transnul . dropLastNull <$> BS.readFile ("/proc/" ++ show pid ++ "/cmdline")
   where dropLastNull s
-          | T.null s = s
-          | T.last s == '\0' = T.init s
+          | BS.null s = s
+          | BS.last s == '\0' = BS.init s
           | otherwise = s
         transnul ch = if ch == '\0' then ' ' else ch
 
@@ -67,8 +65,8 @@ liftUnit n u l =
      then liftUnit (n / 1024) (tail u) (head u)
      else (n, l)
 
-filesize :: (Integral a, Show a) => a -> Text
-filesize n = T.pack $
+filesize :: (Integral a, Show a) => a -> ByteString
+filesize n = BS.pack $
   if unit /= '\0'
      then printf "%.1f%ciB" m unit
      else show n ++ "B"

--- a/Haskell_parallel/package.yaml
+++ b/Haskell_parallel/package.yaml
@@ -14,3 +14,4 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-maxN4
+    - -O2

--- a/Haskell_parallel/package.yaml
+++ b/Haskell_parallel/package.yaml
@@ -4,7 +4,7 @@ version:             0.1.0.0
 dependencies:
 - base >= 4.7 && < 5
 - directory
-- text
+- bytestring
 - monad-parallel
 
 executables:


### PR DESCRIPTION
Straightforward drop-in replacement of `text` by `bytestring`. `ByteString` is a little faster, because it does not incur overheads of encoding and decoding.

Use text:
```
---------Results--------(Diff):  KMinAvg      Min      Avg      Max    Stdev  Cnt
Rust_parallel           (100%):    23.33    22.77    23.98    29.11     1.36   20
C                       (100%):    46.44    46.04    46.78    48.56     0.54   20
LuaJIT                  (100%):   108.30   107.73   109.82   114.46     1.94   20
Haskell_parallel        (100%):   134.39   126.31   138.96   156.84     7.89   20
Haskell                 (100%):   147.67   146.85   149.76   161.36     3.37   20
```

Use bytestring:
```
---------Results--------(Diff):  KMinAvg      Min      Avg      Max    Stdev  Cnt
Rust_parallel           (100%):    24.24    23.34    24.90    27.14     0.95   20
C                       (100%):    46.48    45.76    47.48    51.63     1.46   20
Haskell_parallel        (100%):    83.91    83.79    84.53    94.23     2.29   20
Haskell                 (100%):    87.69    87.09    88.90    92.21     1.60   20
LuaJIT                  (100%):   107.43   106.49   109.57   115.18     2.79   20
```