### PR TITLE
Zig: fix build mode

### DIFF
--- a/Zig/Makefile
+++ b/Zig/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 %: %.zig
-	zig build-exe -Drelease-safe=true --strip $<
+	zig build-exe -O ReleaseSafe --strip $<
 
 all: swapview
 


### PR DESCRIPTION
The `-Drelease-safe=[bool]  optimizations on and safety on` option is a
Project-Specific option, e.g. using in the `zig build` command.
For the `zig build-exe` command we should use `-O ReleaseSafe`, without
this the default build mode Debug is used.