### PR TITLE
Racket_parallel:optimize the implementation

### DIFF
--- a/Racket_parallel/swapview.rkt
+++ b/Racket_parallel/swapview.rkt
@@ -1,6 +1,11 @@
 
-#lang racket
+#lang racket/base
 (require racket/format)
+(require racket/place)
+(require racket/list)
+(require racket/math)
+(require racket/string)
+(require racket/file)
 (provide main)
 ;;use "racket -tm compiled/swapview_rkt.zo"
 


### PR DESCRIPTION
Sorry to disturb you.
According to the Racket Guide,

- When `letrec` is used to bind only procedures and literals, then the compiler can treat the bindings in an optimal manner, compiling uses of the bindings efficiently.
- Primitive operations are inlined at the machine-code level.
- The communication costs for places can be fairly high.
- The racket library is much larger than the sum of the racket/base library, the racket/format library, etc.

After the optimization, the performance had a slight improvement.(Tested on racket8.4, ubuntu20.04, AMD RYZEN7)