### PR TITLE
Racket*:more changes

### DIFF
--- a/Racket/swapview.rkt
+++ b/Racket/swapview.rkt
@@ -1,4 +1,3 @@
-#!/usr/bin/env racket
 #lang racket/base
 (require (only-in racket/format ~a ~r)
          (only-in racket/string string-split string-replace string-prefix?)
@@ -20,10 +19,7 @@
     (newline)))
 
 (define (total n)
-  (begin
-    (display "Total: ")
-    (display (~a n  #:min-width 10 #:align 'right))
-    (newline)))
+  (displayln (~a "Total:  " n #:min-width 10 #:align 'right)))
 
 (define (strinit s)
   (let ([l (string-length s)])

--- a/Racket_parallel/swapview.rkt
+++ b/Racket_parallel/swapview.rkt
@@ -23,9 +23,9 @@
     (define (fmtPid pid) (~a pid  #:width 7 #:align 'right))
     (define (filesize n)
       (if (< n 1100) (format "~aB" n)
-          (let* ([p (exact-floor (log (/ n 1100) 1024))]
-                 [s (~r (/ n (expt 1024 (add1 p))) #:precision '(= 1))]
-                 [unit (string-ref "KMGT" p)])
+          (let ([p (exact-floor (log (/ n 1100) 1024))])
+            (define s (~r (/ n (expt 1024 (add1 p))) #:precision '(= 1)))
+            (define unit (string-ref "KMGT" p))
             (format "~a~aiB" s unit))))
     (define (fmtSize size) (~a size  #:width 9 #:align 'right))
     (define (resolveCmdline s)
@@ -53,13 +53,13 @@
       ((_) #`(let ((pl
                     (place ch
                            (place-channel-put ch (map getAll (list #,@latter))))))
-               (append (map getAll (list #,@former)) (place-channel-get pl))))))
+               (append (map getAll #,(syntax-shift-phase-level #'former -1)) (place-channel-get pl))))))
 
   (define (getResult) (parallel)))
 
 (module* main #f
-  (require (submod ".." helper)
-           (submod ".." shared)
+  (require (only-in (submod ".." helper) getResult)
+           (only-in (submod ".." shared) fmtPid fmtSize filesize)
            racket/match
            (only-in racket/format ~a)
            (submod racket/performance-hint begin-encourage-inline))

--- a/Racket_parallel/swapview.rkt
+++ b/Racket_parallel/swapview.rkt
@@ -66,16 +66,9 @@
 
   (begin-encourage-inline
     (define (fmt1 s1 s2 s3)
-      (begin
-        (map display (list s1 " "
-                           s2 " "
-                           s3))
-        (newline)))
+      (displayln (~a s1 " " s2 " " s3)))
     (define (total n)
-      (begin
-        (display "Total: ")
-        (display (~a n  #:min-width 10 #:align 'right))
-        (newline))))
+      (displayln (~a "Total: " n #:min-width 10 #:align 'right))))
 
   (define result-list (getResult))
 

--- a/Racket_parallel/swapview.rkt
+++ b/Racket_parallel/swapview.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (module* shared #f
-  (require (only-in racket/list split-at filter-map)
+  (require (only-in racket/list split-at)
            (only-in racket/math exact-floor)
            (submod racket/performance-hint begin-encourage-inline)
            (only-in racket/file file->lines file->string)
@@ -9,7 +9,7 @@
            (only-in racket/format ~a ~r))
   (provide former latter getAll fmtPid fmtSize filesize)
 
-  (define pid-list (filter-map string->number (map path->string (directory-list "/proc"))))
+  (define pid-list (filter string->number (map path->string (directory-list "/proc"))))
   (define len (exact-floor (* (length pid-list) 1/2)))
   (define-values (former latter) (split-at pid-list len))
   (begin-encourage-inline
@@ -36,9 +36,9 @@
                      (with-handlers ([exn:fail:filesystem? (lambda (exn) #f)])
                        (let/cc ret
                          (list
-                          (fmtPid pid)
                           (let ((v (getSize (getSmaps pid))))
                             (if (zero? v) (ret #f) (cons v (fmtSize (filesize v)))))
+                          (fmtPid pid)
                           (resolveCmdline (getCmdline pid)))))))))
 
 (module* helper #f
@@ -80,8 +80,8 @@
   (define result-list (getResult))
 
   (define-values (size-list format-result)
-    (match (sort (filter values result-list) #:key caadr <)
-      ((list (list pid (cons size format-size) cmd) ...)
+    (match (sort (filter values result-list) #:key caar <)
+      ((list (list (cons size format-size) pid cmd) ...)
        (values size
                (map (lambda (pid format-size cmd)
                       (list pid format-size cmd))

--- a/Racket_parallel/swapview.rkt
+++ b/Racket_parallel/swapview.rkt
@@ -52,8 +52,8 @@
     (syntax-case stx ()
       ((_) #`(let ((pl
                     (place ch
-                           (place-channel-put ch (map getAll (list #,@latter))))))
-               (append (map getAll #,(syntax-shift-phase-level #'former -1)) (place-channel-get pl))))))
+                           (place-channel-put ch (map getAll '#,latter)))))
+               (append (map getAll '#,former) (place-channel-get pl))))))
 
   (define (getResult) (parallel)))
 

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -196,7 +196,7 @@ dir = "Python3_bytes"
 cmd = ["./swapview.r"]
 
 [item.Racket]
-cmd = ["./swapview.rkt"]
+cmd = ["racket", "./swapview.rkt", "--no-compiled"]
 
 [item.Racket_compiled]
 dir = "Racket"


### PR DESCRIPTION
- A `--no-compiled` flag is added to the `Racket` version to disable loading of compiled ".zo" files and run the program completely with the JIT compiler, which leads to reasonably poorer performance.
- Code is simplified in both the `Racket` version and the `Racket_parallel` version.
- Place the formatting procedure into the `place` form.
- Reduce the cost of allocation.

My result goes as follows.(`Racket[cs]v8.6,Ubuntu22.04,AMD Ryzen7 4800H`)

```
---------Results--------(Diff):  KMinAvg      Min      Avg      Max    Stdev  Cnt
C++98_omp               (100%):    73.83    35.22    93.11   131.50    25.20   20
Python3_mp              (100%):   103.61   100.18   110.86   143.85    12.19   20
Perl_parallel           (100%):   165.22   138.63   185.40   229.25    24.70   20
C++98                   (100%):   181.86   180.76   195.85   214.99    14.92   20
C++14                   (100%):   182.53   179.85   196.40   213.59    14.84   20
Python3                 (100%):   183.74   176.88   195.64   208.73    14.77   20
C                       (100%):   189.13   173.39   200.06   219.66    15.16   20
C++17                   (100%):   190.49   183.33   202.76   218.22    14.03   20
C++11                   ( 97%):   218.63   207.66   229.98   246.63    15.09   20
Python3_bytes           (100%):   287.32   260.98   290.79   298.45     7.98   20
Perl                    (100%):   312.59   284.12   387.37   477.63    79.63   20
ChezScheme              (100%):   433.81   421.33   491.03   674.90    92.40   20
Racket_parallel         ( 98%):   492.10   478.92   503.71   530.51    15.12   20
Racket                  ( 98%):   543.39   521.95   553.22   568.84    13.06   20
Racket_compiled         ( 98%):   546.18   527.33   557.21   584.61    14.21   20
Tcl                     (100%):   790.50   761.15   804.33   827.65    17.51   20
Bash_parallel           (  3%):   806.14   791.45   889.44  1113.12   122.93   20
POSIX_dash              (100%):  1573.27  1530.82  1608.41  1686.28    42.99   20
POSIX_bash              ( 97%):  1963.75  1905.36  2046.30  2218.45    97.38   20
Bash                    ( 76%):  3024.34  2833.89  3093.20  3366.80   103.57   20
```