### PR TITLE
Racket*:several updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ languages = C C++11 C++14 C++14_boost C++17 C++98 \
 		Haskell Haskell_parallel \
 		Go Go_goroutine \
 		Java Nim NodeJS NodeJS_async NodeJS_cluster \
-		OCaml Racket Racket_parallel Rust Rust_parallel \
+		OCaml Racket Racket_parallel Racket_concurrency Rust Rust_parallel \
 		Scala Vala ChezScheme Zig
 		# OCaml_lwt
 

--- a/Racket_concurrency/Makefile
+++ b/Racket_concurrency/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all clean
+
+all: compiled/swapview_rkt.zo
+
+compiled/swapview_rkt.zo: swapview.rkt
+	raco make --no-deps swapview.rkt
+
+run: all
+	racket compiled/swapview_rkt.zo
+
+clean:
+	-rm -rf compiled

--- a/Racket_concurrency/swapview.rkt
+++ b/Racket_concurrency/swapview.rkt
@@ -26,7 +26,8 @@
     (displayln (~a n  #:min-width 10 #:align 'right)))
   
   (define (strinit s)
-    (string-replace s "\x0" ""))
+    (let ((l (string-length s)))
+      (if (zero? l) "" (string-replace (substring s 0 (sub1 l)) "\x0" " "))))
 
   (define (getSwapFor pid)
     (with-handlers ([exn:fail:filesystem? (lambda (e) #f)])

--- a/Racket_concurrency/swapview.rkt
+++ b/Racket_concurrency/swapview.rkt
@@ -33,7 +33,7 @@
     (with-handlers ([exn:fail:filesystem? (lambda (e) #f)])
       (let/cc ret
         (let* ([swap? (lambda (l) (string-prefix? l "Swap:"))]
-               [getSize (lambda (l) (list-ref (string-split l) 1))]
+               [getSize (lambda (l) (string->number (list-ref (string-split l) 1)))]
                [smaps (call-with-input-file (format "/proc/~a/smaps" pid) (lambda (in) (for/fold ((r 0)) ((line (in-lines in)))
                                                                                          (if (swap? line) (+ (getSize line) r) r))))])
           (list pid (* (if (zero? smaps) (ret #f) smaps) 1024) (file->string (format "/proc/~a/cmdline" pid))))))))

--- a/Racket_concurrency/swapview.rkt
+++ b/Racket_concurrency/swapview.rkt
@@ -39,15 +39,16 @@
           (list pid (* (if (zero? smaps) (ret #f) smaps) 1024) (file->string (format "/proc/~a/cmdline" pid))))))))
   
 (define (main)
-  (fmt1 "PID" "SWAP" "COMMAND")
-  
+    
   (define channel (make-async-channel))
   
   (define thd (thread (lambda () (let loop ((pid-list (sort (filter-map (compose string->number path->string) (directory-list "/proc")) <)))
                                     (cond ((null? pid-list) (async-channel-put channel #f))
-                                          (else (async-channel-put channel (getSwapFor (car pid-list)))
+                                          (else (define v (getSwapFor (car pid-list)))
+                                                (cond (v (async-channel-put channel v)))
                                                 (loop (cdr pid-list))))))))
-  
+  (fmt1 "PID" "SWAP" "COMMAND")
+
   (let loop ((t 0))
     (define v (sync channel))
     (cond (v

--- a/Racket_concurrency/swapview.rkt
+++ b/Racket_concurrency/swapview.rkt
@@ -34,10 +34,9 @@
       (let/cc ret
         (let* ([swap? (lambda (l) (string-prefix? l "Swap:"))]
                [getSize (lambda (l) (list-ref (string-split l) 1))]
-               [smaps (call-with-input-file (format "/proc/~a/smaps" pid) (lambda (in) (for/fold ((r null)) ((line (in-lines in)))
-                                                                                         (if (swap? line) (cons line r) r))))] 
-               [size (apply + (map (compose string->number getSize) smaps))])
-          (list pid (* (if (zero? size) (ret #f) size) 1024) (file->string (format "/proc/~a/cmdline" pid))))))))
+               [smaps (call-with-input-file (format "/proc/~a/smaps" pid) (lambda (in) (for/fold ((r 0)) ((line (in-lines in)))
+                                                                                         (if (swap? line) (+ (getSize line) r) r))))])
+          (list pid (* (if (zero? smaps) (ret #f) smaps) 1024) (file->string (format "/proc/~a/cmdline" pid))))))))
   
 (define (main)
   (fmt1 "PID" "SWAP" "COMMAND")

--- a/Racket_concurrency/swapview.rkt
+++ b/Racket_concurrency/swapview.rkt
@@ -1,0 +1,67 @@
+#lang racket/base
+(require (only-in racket/format ~a ~r)
+         (submod racket/performance-hint begin-encourage-inline)
+         (only-in racket/list filter-map)
+         (only-in racket/string string-split string-replace string-prefix?)
+         (only-in racket/file file->string)
+         (only-in racket/async-channel make-async-channel async-channel-put)
+         (only-in racket/math exact-floor))
+(provide main)
+;; Compile with `raco make --no-deps`
+(begin-encourage-inline
+  (define (filesize n)
+    (if (< n 1100) (format "~aB" n)
+        (letrec ([p (exact-floor (/ (log (/ n 1100)) (log 1024)))]
+                 [s (~r (/ n (expt 1024 (add1 p))) #:precision '(= 1))]
+                 [unit (string-ref "KMGT" p)])
+          (format "~a~aiB" s unit))))
+  
+  (define (fmt1 s1 s2 s3)
+    (displayln (~a (~a s1 #:width 7 #:align 'right) " "
+                   (~a s2 #:width 9 #:align 'right) " "
+                   s3)))
+  
+  (define (total n)
+    (display "Total: ")
+    (displayln (~a n  #:min-width 10 #:align 'right)))
+  
+  (define (strinit s)
+    (string-replace s "\x0" ""))
+
+  (define (getSwapFor pid)
+    (with-handlers ([exn:fail:filesystem? (lambda (e) #f)])
+      (let/cc ret
+        (let* ([swap? (lambda (l) (string-prefix? l "Swap:"))]
+               [getSize (lambda (l) (list-ref (string-split l) 1))]
+               [smaps (call-with-input-file (format "/proc/~a/smaps" pid) (lambda (in) (for/fold ((r null)) ((line (in-lines in)))
+                                                                                         (if (swap? line) (cons line r) r))))] 
+               [size (apply + (map (compose string->number getSize) smaps))])
+          (list pid (* (if (zero? size) (ret #f) size) 1024) (file->string (format "/proc/~a/cmdline" pid))))))))
+  
+(define (main)
+  (fmt1 "PID" "SWAP" "COMMAND")
+  
+  (define in-channel (make-async-channel))
+  (define out-channel (make-async-channel))
+  
+  (define thd1 (thread (lambda () (let loop ()
+                                    (define pid (sync in-channel))
+                                    (cond (pid (async-channel-put out-channel (getSwapFor pid))
+                                               (loop))
+                                          (else (async-channel-put out-channel #f)))))))
+  
+  (define thd2 (thread (lambda () (let loop ((t 0))
+                                    (define v (sync out-channel))
+                                    (cond (v
+                                           (fmt1 (car v) (filesize (cadr v)) (strinit (caddr v)))
+                                           (loop (+ t (cadr v))))
+                                          (else (total (filesize t))))))))
+  
+  (define pidlist (sort (filter-map (compose string->number path->string) (directory-list "/proc")) <))
+  
+  (map (lambda (p) (async-channel-put in-channel p)) pidlist)
+  (async-channel-put in-channel #f)
+  
+  (void (sync (thread-dead-evt thd2))))
+
+(main)

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -196,7 +196,7 @@ dir = "Python3_bytes"
 cmd = ["./swapview.r"]
 
 [item.Racket]
-cmd = ["racket", "./swapview.rkt", "--no-compiled"]
+cmd = ["racket", "--no-compiled", "./swapview.rkt"]
 
 [item.Racket_compiled]
 dir = "Racket"
@@ -204,6 +204,10 @@ cmd = ["racket", "compiled/swapview_rkt.zo"]
 
 [item.Racket_parallel]
 dir = "Racket_parallel"
+cmd = ["racket", "-t", "compiled/swapview_rkt.zo"]
+
+[item.Racket_concurrency]
+dir = "Racket_concurrency"
 cmd = ["racket", "-t", "compiled/swapview_rkt.zo"]
 
 [item.Ruby]


### PR DESCRIPTION
- Add a `Racket_concurrency` version, which is much faster than the `Racket_parallel` version.
- Speed up the `Racket` version
- Fix the position of `--no-compiled` flag, which leads to very poor performance